### PR TITLE
Bump dependency to library-chart v1.1.0

### DIFF
--- a/charts/jupyter-pyspark-gpu/Chart.yaml
+++ b/charts/jupyter-pyspark-gpu/Chart.yaml
@@ -15,5 +15,5 @@ type: application
 version: 1.12.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ version: 1.12.0
 
 dependencies:
   - name: library-chart
-    version: 1.0.3
+    version: 1.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python-gpu/Chart.yaml
+++ b/charts/jupyter-python-gpu/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 version: 1.5.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -26,5 +26,5 @@ version: 1.5.0
 
 dependencies:
   - name: library-chart
-    version: 1.0.3
+    version: 1.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch-gpu/Chart.yaml
+++ b/charts/jupyter-pytorch-gpu/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 version: 1.5.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch/Chart.yaml
+++ b/charts/jupyter-pytorch/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 version: 1.5.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-r/Chart.yaml
+++ b/charts/jupyter-r/Chart.yaml
@@ -26,5 +26,5 @@ version: 1.4.0
 
 dependencies:
   - name: library-chart
-    version: 1.0.3
+    version: 1.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow-gpu/Chart.yaml
+++ b/charts/jupyter-tensorflow-gpu/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 version: 1.5.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow/Chart.yaml
+++ b/charts/jupyter-tensorflow/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 version: 1.5.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 version: 1.5.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -27,5 +27,5 @@ version: 1.4.0
 
 dependencies:
   - name: library-chart
-    version: 1.0.3
+    version: 1.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -26,5 +26,5 @@ version: 1.5.0
 
 dependencies:
   - name: library-chart
-    version: 1.0.3
+    version: 1.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python-gpu/Chart.yaml
+++ b/charts/vscode-python-gpu/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 version: 1.3.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -26,5 +26,5 @@ version: 1.3.0
 
 dependencies:
   - name: library-chart
-    version: 1.0.3
+    version: 1.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch-gpu/Chart.yaml
+++ b/charts/vscode-pytorch-gpu/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 version: 1.3.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch/Chart.yaml
+++ b/charts/vscode-pytorch/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 version: 1.3.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow-gpu/Chart.yaml
+++ b/charts/vscode-tensorflow-gpu/Chart.yaml
@@ -14,5 +14,5 @@ type: application
 version: 1.3.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow/Chart.yaml
+++ b/charts/vscode-tensorflow/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 version: 1.3.0
 dependencies:
 - name: library-chart
-  version: 1.0.3
+  version: 1.1.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services


### PR DESCRIPTION
This was the intended version for https://github.com/InseeFrLab/helm-charts-interactive-services/pull/18, but we had to roll that back in order to *first* be able to build `library-chart` v1.1.0.