### PR TITLE
Bump chart version by 0.0.1 to allow rebuild

### DIFF
--- a/charts/jupyter-pyspark-gpu/Chart.yaml
+++ b/charts/jupyter-pyspark-gpu/Chart.yaml
@@ -12,7 +12,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.12.0
+version: 1.12.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.0
+version: 1.12.1
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-python-gpu/Chart.yaml
+++ b/charts/jupyter-python-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-pytorch-gpu/Chart.yaml
+++ b/charts/jupyter-pytorch-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/jupyter-pytorch/Chart.yaml
+++ b/charts/jupyter-pytorch/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/jupyter-r/Chart.yaml
+++ b/charts/jupyter-r/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-tensorflow-gpu/Chart.yaml
+++ b/charts/jupyter-tensorflow-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/jupyter-tensorflow/Chart.yaml
+++ b/charts/jupyter-tensorflow/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python-gpu/Chart.yaml
+++ b/charts/vscode-python-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.3.0
+version: 1.3.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-pytorch-gpu/Chart.yaml
+++ b/charts/vscode-pytorch-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.3.0
+version: 1.3.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/vscode-pytorch/Chart.yaml
+++ b/charts/vscode-pytorch/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.3.0
+version: 1.3.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/vscode-tensorflow-gpu/Chart.yaml
+++ b/charts/vscode-tensorflow-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.3.0
+version: 1.3.1
 dependencies:
 - name: library-chart
   version: 1.1.0

--- a/charts/vscode-tensorflow/Chart.yaml
+++ b/charts/vscode-tensorflow/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.3.0
+version: 1.3.1
 dependencies:
 - name: library-chart
   version: 1.1.0


### PR DESCRIPTION
Hopefully this is the last one. Summary of the trials and tribulations : 

- https://github.com/InseeFrLab/helm-charts-interactive-services/pull/18 bumped all the charts versions (library-charts + the various IDEs), which caused the `release` Github Action to fail : the IDE charts had a dependency on a version of `library-chart` which was not built.
- https://github.com/InseeFrLab/helm-charts-interactive-services/pull/21 then downgraded the IDE charts' dependency to `library-chart`, in order to allow building the new version for `library-chart` itself (v 1.1.0)... but this also built the IDE charts with their new version from #18
- https://github.com/InseeFrLab/helm-charts-interactive-services/pull/22 was intended to rebuild the IDE charts with the proper version for `library-charts` (v1.1.0)... but the build failed, because these charts versions were left unchanged.
- This current PR is made just to bump these IDE charts' version by 0.0.1, just to allow a proper rebuild.