### PR TITLE
[RStudio] Update the version enums (remove 'ds-' + downgrade)

### DIFF
--- a/charts/children.yaml
+++ b/charts/children.yaml
@@ -35,8 +35,8 @@ rstudio:
   rstudio-gpu:
     description: The RStudio IDE with a collection of standard data science packages, with GPU support.
     images:
-      - inseefrlab/onyxia-rstudio:ds-r4.2.3-gpu
-      - inseefrlab/onyxia-rstudio:ds-r4.1.2-gpu
+      - inseefrlab/onyxia-rstudio:r4.2.1-gpu
+      - inseefrlab/onyxia-rstudio:r4.1.3-gpu
 
 vscode-python:
   vscode-python-gpu:

--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.1
+version: 1.6.2
 dependencies:
 - name: library-chart
   version: 1.3.0

--- a/charts/rstudio-gpu/values.schema.json
+++ b/charts/rstudio-gpu/values.schema.json
@@ -24,15 +24,15 @@
               "description": "supported versions",
               "type": "string",
               "enum": [
-                "inseefrlab/onyxia-rstudio:r4.2.3-gpu",
-                "inseefrlab/onyxia-rstudio:r4.1.2-gpu"
+                "inseefrlab/onyxia-rstudio:r4.2.1-gpu",
+                "inseefrlab/onyxia-rstudio:r4.1.3-gpu"
               ],
               "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
               "hidden": {
                 "value": true,
                 "path": "service/image/custom/enabled"
               },
-              "default": "inseefrlab/onyxia-rstudio:r4.2.3-gpu"
+              "default": "inseefrlab/onyxia-rstudio:r4.2.1-gpu"
             },
             "custom": {
               "description": "use a custom RStudio docker image",
@@ -47,7 +47,7 @@
                 "version": {
                   "description": "RStudio unsupported version",
                   "type": "string",
-                  "default": "inseefrlab/onyxia-rstudio:r4.2.3-gpu",
+                  "default": "inseefrlab/onyxia-rstudio:r4.2.1-gpu",
                   "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                   "hidden": {
                     "value": false,

--- a/charts/rstudio-gpu/values.schema.json
+++ b/charts/rstudio-gpu/values.schema.json
@@ -24,15 +24,15 @@
               "description": "supported versions",
               "type": "string",
               "enum": [
-                "inseefrlab/onyxia-rstudio:ds-r4.2.3-gpu",
-                "inseefrlab/onyxia-rstudio:ds-r4.1.2-gpu"
+                "inseefrlab/onyxia-rstudio:r4.2.3-gpu",
+                "inseefrlab/onyxia-rstudio:r4.1.2-gpu"
               ],
               "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
               "hidden": {
                 "value": true,
                 "path": "service/image/custom/enabled"
               },
-              "default": "inseefrlab/onyxia-rstudio:ds-r4.2.3-gpu"
+              "default": "inseefrlab/onyxia-rstudio:r4.2.3-gpu"
             },
             "custom": {
               "description": "use a custom RStudio docker image",
@@ -47,7 +47,7 @@
                 "version": {
                   "description": "RStudio unsupported version",
                   "type": "string",
-                  "default": "inseefrlab/onyxia-rstudio:ds-r4.2.3-gpu",
+                  "default": "inseefrlab/onyxia-rstudio:r4.2.3-gpu",
                   "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                   "hidden": {
                     "value": false,

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.1
+version: 1.6.2
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -20,15 +20,15 @@
                         "description": "supported versions",
                         "type": "string",
                         "enum": [
-                            "inseefrlab/onyxia-rstudio:ds-r4.2.3",
-                            "inseefrlab/onyxia-rstudio:ds-r4.1.2"
+                            "inseefrlab/onyxia-rstudio:r4.2.3",
+                            "inseefrlab/onyxia-rstudio:r4.1.2"
                           ],
                         "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                         "hidden": {
                             "value": true,
                             "path": "service/image/custom/enabled"
                         },
-                        "default": "inseefrlab/onyxia-rstudio:ds-r4.2.3"
+                        "default": "inseefrlab/onyxia-rstudio:r4.2.3"
                       },
                       "custom" : {
                         "description": "use a custom RStudio docker image",
@@ -43,7 +43,7 @@
                           "version": {
                             "description": "RStudio unsupported version",
                             "type": "string",
-                            "default": "inseefrlab/onyxia-rstudio:ds-r4.2.3",
+                            "default": "inseefrlab/onyxia-rstudio:r4.2.3",
                             "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                             "hidden": {
                                 "value": false,

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -20,15 +20,15 @@
                         "description": "supported versions",
                         "type": "string",
                         "enum": [
-                            "inseefrlab/onyxia-rstudio:r4.2.3",
-                            "inseefrlab/onyxia-rstudio:r4.1.2"
+                            "inseefrlab/onyxia-rstudio:r4.2.1",
+                            "inseefrlab/onyxia-rstudio:r4.1.3"
                           ],
                         "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                         "hidden": {
                             "value": true,
                             "path": "service/image/custom/enabled"
                         },
-                        "default": "inseefrlab/onyxia-rstudio:r4.2.3"
+                        "default": "inseefrlab/onyxia-rstudio:r4.2.1"
                       },
                       "custom" : {
                         "description": "use a custom RStudio docker image",
@@ -43,7 +43,7 @@
                           "version": {
                             "description": "RStudio unsupported version",
                             "type": "string",
-                            "default": "inseefrlab/onyxia-rstudio:r4.2.3",
+                            "default": "inseefrlab/onyxia-rstudio:r4.2.1",
                             "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                             "hidden": {
                                 "value": false,


### PR DESCRIPTION
Hello,

Quick PR to suggest a correction on the various version enums in the `value.schema.json` files for `rstudio` and `rstudio-gpu`.

I removed the `ds-` part (which seems to have disappeared), and also *downgraded* the version - this seems counterintuitive, but I just followed the tags visible here : https://hub.docker.com/r/inseefrlab/onyxia-rstudio/tags.

Might have missed something though, in which case, thanks for telling me where. :)