### PR TITLE
Add missing checks for config maps in stateful set template

### DIFF
--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.1
+version: 1.16.2
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-pyspark/templates/statefulset.yaml
+++ b/charts/jupyter-pyspark/templates/statefulset.yaml
@@ -43,9 +43,11 @@ spec:
           configMap:
             name: {{ include "library-chart.configMapNameHive" . }}
         {{- end }}
+        {{- if .Values.s3.enabled }}
         - name: config-coresite
           configMap:
             name: {{ include "library-chart.configMapNameCoreSite" . }}
+        {{- end }}
         {{- if .Values.discovery.metaflow }}
         - name: metaflow-config
           configMap:
@@ -152,9 +154,11 @@ spec:
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
               name: home
+            {{- if .Values.s3.enabled }}
             - mountPath: /opt/hadoop/etc/hadoop/core-site.xml
               subPath: core-site.xml
               name: config-coresite
+            {{- end }}
             {{- if .Values.spark.default }}
             - name: config-sparkconf
               mountPath: /opt/spark/conf/spark-defaults.conf

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.2
+version: 1.5.3
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio-sparkr/templates/statefulset.yaml
+++ b/charts/rstudio-sparkr/templates/statefulset.yaml
@@ -42,12 +42,16 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+        {{- if .Values.s3.enabled }}
         - name: config-coresite
           configMap:
             name: {{ include "library-chart.configMapNameCoreSite" . }}
+        {{- end }}
+        {{- if .Values.spark.default }}
         - name: config-sparkconf
           configMap:
             name: {{ include "library-chart.configMapNameSparkConf" . }}
+        {{- end }}
         {{- if .Values.discovery.hive }}
         - name: hive-config
           configMap:
@@ -138,9 +142,11 @@ spec:
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user }}/work
               name: home
+            {{- if .Values.s3.enabled }}
             - mountPath: /opt/hadoop/etc/hadoop/core-site.xml
               subPath: core-site.xml
               name: config-coresite
+            {{- end }}
             {{- if .Values.spark.default }}
             - name: config-sparkconf
               mountPath: /opt/spark/conf/spark-defaults.conf


### PR DESCRIPTION
After tripping on this per chance, here's a quick PR to add some conditionals in the stateful set template of two different charts. To be precise : 

 - jupyter-spark : added `{{- if .Values.s3.enabled }}` twice to condition the "core site" config map
 - rstudio-sparkr : same as abobe + added `{{- if .Values.spark.default }}` once to condition the "spark conf" config map

These checks are already present in `library-chart` ([see here for instance](https://github.com/InseeFrLab/helm-charts-interactive-services/blob/2dfb75622d8a54162bdd8b039efafc5fc90090b2/charts/library-chart/templates/_configmap.tpl#L187))