### PR TITLE
library-chart : add custom maven repository management

### DIFF
--- a/charts/jupyter-pyspark-gpu/Chart.yaml
+++ b/charts/jupyter-pyspark-gpu/Chart.yaml
@@ -13,8 +13,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.16.5
+version: 1.16.6
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark-gpu/Chart.yaml
+++ b/charts/jupyter-pyspark-gpu/Chart.yaml
@@ -13,8 +13,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.16.2
+version: 1.16.3
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark-gpu/Chart.yaml
+++ b/charts/jupyter-pyspark-gpu/Chart.yaml
@@ -13,8 +13,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.16.4
+version: 1.16.5
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark-gpu/Chart.yaml
+++ b/charts/jupyter-pyspark-gpu/Chart.yaml
@@ -13,8 +13,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.16.3
+version: 1.16.4
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.5
+version: 1.16.6
 
 dependencies:
   - name: library-chart
-    version: 1.3.4
+    version: 1.3.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.2
+version: 1.16.3
 
 dependencies:
   - name: library-chart
-    version: 1.3.1
+    version: 1.3.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.3
+version: 1.16.4
 
 dependencies:
   - name: library-chart
-    version: 1.3.2
+    version: 1.3.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.4
+version: 1.16.5
 
 dependencies:
   - name: library-chart
-    version: 1.3.3
+    version: 1.3.4
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python-gpu/Chart.yaml
+++ b/charts/jupyter-python-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.4
+version: 1.6.5
 dependencies:
 - name: library-chart
   version: 1.3.2

--- a/charts/jupyter-python-gpu/Chart.yaml
+++ b/charts/jupyter-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.7
+version: 1.6.8
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python-gpu/Chart.yaml
+++ b/charts/jupyter-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.5
+version: 1.6.6
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python-gpu/Chart.yaml
+++ b/charts/jupyter-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.6
+version: 1.6.7
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python-gpu/Chart.yaml
+++ b/charts/jupyter-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.3
+version: 1.6.4
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.7
+version: 1.6.8
 
 dependencies:
   - name: library-chart
-    version: 1.3.4
+    version: 1.3.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.6
+version: 1.6.7
 
 dependencies:
   - name: library-chart
-    version: 1.3.3
+    version: 1.3.4
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.4
+version: 1.6.5
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,10 +22,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.3
+version: 1.6.4
 
 dependencies:
   - name: library-chart
-    version: 1.3.1
+    version: 1.3.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services
    # repository: "file://../library-chart"

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,10 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.5
+version: 1.6.6
 
 dependencies:
   - name: library-chart
-    version: 1.3.2
+    version: 1.3.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services
-   # repository: "file://../library-chart"

--- a/charts/jupyter-pytorch-gpu/Chart.yaml
+++ b/charts/jupyter-pytorch-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.4
+version: 1.6.5
 dependencies:
 - name: library-chart
   version: 1.3.2

--- a/charts/jupyter-pytorch-gpu/Chart.yaml
+++ b/charts/jupyter-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.7
+version: 1.6.8
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch-gpu/Chart.yaml
+++ b/charts/jupyter-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.5
+version: 1.6.6
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch-gpu/Chart.yaml
+++ b/charts/jupyter-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.6
+version: 1.6.7
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch-gpu/Chart.yaml
+++ b/charts/jupyter-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.3
+version: 1.6.4
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch/Chart.yaml
+++ b/charts/jupyter-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.7
+version: 1.6.8
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch/Chart.yaml
+++ b/charts/jupyter-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.5
+version: 1.6.6
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch/Chart.yaml
+++ b/charts/jupyter-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.3
+version: 1.6.4
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch/Chart.yaml
+++ b/charts/jupyter-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.6
+version: 1.6.7
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pytorch/Chart.yaml
+++ b/charts/jupyter-pytorch/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.4
+version: 1.6.5
 dependencies:
 - name: library-chart
   version: 1.3.2

--- a/charts/jupyter-r/Chart.yaml
+++ b/charts/jupyter-r/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.7
+version: 1.6.8
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-r/Chart.yaml
+++ b/charts/jupyter-r/Chart.yaml
@@ -1,30 +1,17 @@
 apiVersion: v2
 name: jupyter-r
-description: The JupyterLab IDE with an R kernel, and a collection of standard data science packages.
+description: The JupyterLab IDE with R and a collection of standard data science packages.
 icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/jupyter.png
 keywords:
-  - Jupyter
-  - R
+- Jupyter
+- Python
 home: https://jupyter.org/
 sources:
-  - https://github.com/InseeFrLab/images-datascience
-  - https://github.com/InseeFrLab/helm-charts-interactive-services
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+- https://github.com/InseeFrLab/images-datascience
+- https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.2
-
+version: 1.6.4
 dependencies:
-  - name: library-chart
-    version: 1.3.1
-    repository: https://inseefrlab.github.io/helm-charts-interactive-services
+- name: library-chart
+  version: 1.3.2
+  repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-r/Chart.yaml
+++ b/charts/jupyter-r/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.5
+version: 1.6.6
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-r/Chart.yaml
+++ b/charts/jupyter-r/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.6
+version: 1.6.7
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-r/Chart.yaml
+++ b/charts/jupyter-r/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.4
+version: 1.6.5
 dependencies:
 - name: library-chart
   version: 1.3.2

--- a/charts/jupyter-r/templates/NOTES.txt
+++ b/charts/jupyter-r/templates/NOTES.txt
@@ -1,23 +1,18 @@
 {{- if .Values.ingress.enabled }}
 - You can connect to this jupyter with your browser on this [link](http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }})
-{{- end }}
-{{- if .Values.route.enabled }}
-- You can connect to this jupyter with your browser on this [link](https://{{ .Values.route.hostname }})
-{{- end }}
-- Your access token is **{{ .Values.security.password }}**
-
-{{- if .Values.ingress.enabled }}
 {{- if .Values.networking.user.enabled }}
 - You can connect to your custom port on this [link](http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.userHostname }})
 If you don't run your custom service you will get a 502 bad gateway error.
 {{- end }}
 {{- end }}
 {{- if .Values.route.enabled }}
+- You can connect to this jupyter with your browser on this [link](https://{{ .Values.route.hostname }})
 {{- if .Values.networking.user.enabled }}
 - You can connect to your custom port on this [link](https://{{ .Values.route.userHostname }})
 If you don't run your custom service you will get a 502 bad gateway error.
 {{- end }}
 {{- end }}
+- Your access token is **{{ .Values.security.password }}**
 
 *NOTES about deletion :*
 

--- a/charts/jupyter-r/templates/configmap-hive.yaml
+++ b/charts/jupyter-r/templates/configmap-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapHive" . }}

--- a/charts/jupyter-r/templates/configmap-metaflow.yaml
+++ b/charts/jupyter-r/templates/configmap-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapMetaflow" . }}

--- a/charts/jupyter-r/templates/configmap-mlflow.yaml
+++ b/charts/jupyter-r/templates/configmap-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapMLFlow" . }}

--- a/charts/jupyter-r/templates/statefulset.yaml
+++ b/charts/jupyter-r/templates/statefulset.yaml
@@ -28,6 +28,12 @@ spec:
         {{- if (include "library-chart.repository.enabled"  .) }}
         checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
         {{- end }}
+        {{- if not (empty (trim (include "library-chart.configMapMLFlow" .)))}}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/configmap-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.configMapHive" .)))}}
+        checksum/hive: {{ include (print $.Template.BasePath "/configmap-hive.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -41,6 +47,16 @@ spec:
             claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.discovery.hive }}
+        - name: hive-config
+          configMap:
+            name: {{ include "library-chart.configMapNameHive" . }}
+        {{- end }}
+        {{- if .Values.discovery.metaflow }}
+        - name: metaflow-config
+          configMap:
+            name: {{ include "library-chart.configMapNameMetaflow" . }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -117,6 +133,10 @@ spec:
             - configMapRef:
                 name: {{ include "library-chart.configMapNameRepository" . }}
             {{- end }}
+            {{- if not (empty (trim (include "library-chart.configMapMLFlow" .)))}}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameMLFlow" . }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8888
@@ -138,7 +158,17 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
-              name: home   
+              name: home
+            {{- if .Values.discovery.hive }}
+            - name: hive-config
+              mountPath: /opt/hive/conf/hive-site.xml
+              subPath: hive-site.xml
+            {{- end }}   
+            {{- if .Values.discovery.metaflow }}
+            - name: metaflow-config
+              mountPath: /home/{{ .Values.environment.user}}/.metaflowconfig/config.json
+              subPath: config.json
+            {{- end }}     
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jupyter-r/values.schema.json
+++ b/charts/jupyter-r/values.schema.json
@@ -1,672 +1,724 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "service": {
-            "description": "Service specific configuration",
-            "type": "object",
-            "properties": {
-                "image" : {
-                    "description": "image docker",
-                    "type": "object",  
-                    "properties": {
-                      "pullPolicy": {
-                        "type": "string",
-                        "description": "option when pulling the docker image",
-                        "default": "IfNotPresent",
-                        "enum": ["IfNotPresent","Always","Never"]
-                      },
-                      "version": {
-                        "description": "supported versions",
-                        "type": "string",
-                        "enum": [
-                            "inseefrlab/onyxia-jupyter-r:r4.2.3",
-                            "inseefrlab/onyxia-jupyter-r:r4.1.2"
-                          ],
-                        "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
-                        "hidden": {
-                            "value": true,
-                            "path": "service/image/custom/enabled"
-                        },
-                        "default": "inseefrlab/onyxia-jupyter-r:r4.2.3"
-                      },
-                      "custom" : {
-                        "description": "use a custom jupyter docker image",
-                        "type": "object",  
-                        "properties": {
-                          "enabled": {
-                            "title": "custom image",
-                            "type": "boolean",
-                            "description": "use a custom jupyter docker image",
-                            "default": false
-                          },
-                          "version": {
-                            "description": "jupyter unsupported version",
-                            "type": "string",
-                            "default": "inseefrlab/onyxia-jupyter-r:r4.2.3",
-                            "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
-                            "hidden": {
-                                "value": false,
-                                "path": "service/image/custom/enabled"
-                            }
-                          }
-                        }        
-                      }
-                    }        
-                }
-            }
-        },
-          "resources": {
-            "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
-            "type": "object",
-            "properties": {
-                "requests": {
-                    "description": "Guaranteed resources",
-                    "type": "object",
-                    "properties": {
-                      "cpu": {
-                        "description": "The amount of cpu guaranteed",
-                        "title": "CPU",
-                        "type": "string",
-                        "default": "100m",
-                        "render": "slider",
-                        "sliderMin": 50,
-                        "sliderMax": 40000,
-                        "sliderStep": 50,
-                        "sliderUnit": "m",
-                        "sliderExtremity": "down",
-                        "sliderExtremitySemantic": "guaranteed",
-                        "sliderRangeId": "cpu"
-                      },
-                      "memory": {
-                        "description": "The amount of memory guaranteed",
-                        "title": "memory",
-                        "type": "string",
-                        "default": "2Gi",
-                        "render": "slider",
-                        "sliderMin": 1,
-                        "sliderMax": 200,
-                        "sliderStep": 1,
-                        "sliderUnit": "Gi",
-                        "sliderExtremity": "down",
-                        "sliderExtremitySemantic": "guaranteed",
-                        "sliderRangeId": "memory"
-                      }
-                    }
-                },
-                "limits": {
-                    "description": "max resources",
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "description": "The maximum amount of cpu",
-                            "title": "CPU",
-                            "type": "string",
-                            "default": "30000m",
-                            "render": "slider",
-                            "sliderMin": 50,
-                            "sliderMax": 40000,
-                            "sliderStep": 50,
-                            "sliderUnit": "m",
-                            "sliderExtremity": "up",
-                            "sliderExtremitySemantic": "Maximum",
-                            "sliderRangeId": "cpu"
-                          },
-                          "memory": {
-                            "description": "The maximum amount of memory",
-                            "title": "Memory", 
-                            "type": "string",
-                            "default": "50Gi",
-                            "render": "slider",
-                            "sliderMin": 1,
-                            "sliderMax": 200,
-                            "sliderStep": 1,
-                            "sliderUnit": "Gi",
-                            "sliderExtremity": "up",
-                            "sliderExtremitySemantic": "Maximum",
-                            "sliderRangeId": "memory"
-                          }
-                    }
-                }
-            }
-        },
-        "persistence": {
-            "description": "Configuration for persistence",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Create a persistent volume",
-                    "default": true
-                },
-                "size": {
-                    "type": "string",
-                    "title": "Persistent volume size",
-                    "description": "Size of the persistent volume",
-                    "default": "10Gi",
-                    "form": true,
-                    "render": "slider",
-                    "sliderMin": 1,
-                    "sliderMax": 100,
-                    "sliderStep": 1,
-                    "sliderUnit": "Gi",
-                    "hidden": {
-                      "value": false,
-                      "path": "persistence/enabled"
-                    }                    
-                }
-            }
-        },
-        "security": {
-            "description": "security specific configuration",
-            "type": "object",
-            "properties": {
-                "password": {
-                    "type": "string",
-                    "description": "Password",
-                    "default": "changeme",
-                    "render": "password",
-                    "x-form": {
-                        "value": "{{project.password}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{project.password}}"
-                    }
-                },
-                "allowlist": {
-                    "type": "object",
-                    "description": "IP protection",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean",
-                        "title": "Enable IP protection",
-                        "description": "Only the configured set of IPs will be able to reach the service",
-                        "default": true,
-                        "x-form": {
-                          "value": "{{region.defaultIpProtection}}"
-                        },
-                        "x-onyxia": {
-                            "overwriteDefaultWith": "region.defaultIpProtection"
-                        }
-                      },
-                      "ip": {
-                        "type": "string",
-                        "description": "the white list of IP is whitespace",
-                        "title": "Whitelist of IP",
-                        "x-form": {
-                          "value": "{{user.ip}}"
-                        },
-                        "x-onyxia": {
-                            "overwriteDefaultWith": "{{user.ip}}"
-                        },
-                        "hidden": {
-                            "value": false,
-                            "path": "security/allowlist/enabled"
-                        } 
-                      }
-                    }
-                },
-                "networkPolicy": {
-                    "type": "object",
-                    "description": "Define access policy to the service",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean",
-                        "title": "Enable network policy",
-                        "description": "Only pod from the same namespace will be allowed",
-                        "default": true,
-                        "x-form": {
-                          "value": "{{region.defaultNetworkPolicy}}"
-                        },
-                        "x-onyxia": {
-                            "overwriteDefaultWith": "region.defaultNetworkPolicy"
-                        }
-                      },
-                      "from": {
-                        "type": "array",
-                        "description": "Array of source allowed to have network access to your service",
-                        "default" : [], 
-                        "x-form": {
-                          "hidden": true,
-                          "value": "{{region.from}}"
-                        },
-                        "x-onyxia": {
-                            "hidden": true,
-                            "overwriteDefaultWith": "region.from"
-                        }
-                      }
-                    }
-                }
-            }
-        },
-        "kubernetes": {
-          "description": "configuration of your kubernetes access",
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "service": {
+      "description": "Service specific configuration",
+      "type": "object",
+      "properties": {
+        "image": {
+          "description": "image docker",
           "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "type": "string",
+              "description": "option when pulling the docker image",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "description": "supported versions",
+              "type": "string",
+              "enum": [
+                "inseefrlab/onyxia-jupyter-r:r4.2.3",
+                "inseefrlab/onyxia-jupyter-r:r4.1.2"
+              ],
+              "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              },
+              "default": "inseefrlab/onyxia-jupyter-r:r4.2.3"
+            },
+            "custom": {
+              "description": "use a custom jupyter docker image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "custom image",
+                  "type": "boolean",
+                  "description": "use a custom jupyter docker image",
+                  "default": false
+                },
+                "version": {
+                  "description": "jupyter unsupported version",
+                  "type": "string",
+                  "default": "inseefrlab/onyxia-jupyter-r:r4.2.3",
+                  "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
+                  "hidden": {
+                    "value": false,
+                    "path": "service/image/custom/enabled"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "description": "configure your service to autodetect some ressources.",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "type": "boolean",
+          "title": "Enable hive metastore discovery",
+          "description": "discover your hive metastore service",
+          "default": true
+        },
+        "mlflow": {
+          "type": "boolean",
+          "title": "Enable mlflow discovery",
+          "description": "discover your mlflow service",
+          "default": true
+        },
+        "metaflow": {
+          "type": "boolean",
+          "title": "Enable metaflow discovery",
+          "description": "discover your metaflow service",
+          "default": true
+        }
+      }
+    },
+    "resources": {
+      "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
+      "type": "object",
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "The amount of cpu guaranteed",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu"
+            },
+            "memory": {
+              "description": "The amount of memory guaranteed",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory"
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "The maximum amount of cpu",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu"
+            },
+            "memory": {
+              "description": "The maximum amount of memory",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory"
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "description": "Configuration for persistence",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Create a persistent volume",
+          "default": true
+        },
+        "size": {
+          "type": "string",
+          "title": "Persistent volume size",
+          "description": "Size of the persistent volume",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "hidden": {
+            "value": false,
+            "path": "persistence/enabled"
+          }
+        }
+      }
+    },
+    "security": {
+      "description": "security specific configuration",
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string",
+          "description": "Password",
+          "default": "changeme",
+          "render": "password",
+          "x-form": {
+            "value": "{{project.password}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{project.password}}"
+          }
+        },
+        "allowlist": {
+          "type": "object",
+          "description": "IP protection",
           "properties": {
             "enabled": {
               "type": "boolean",
-              "description": "allow your service to access your namespace ressources",
-              "default": true
+              "title": "Enable IP protection",
+              "description": "Only the configured set of IPs will be able to reach the service",
+              "default": true,
+              "x-form": {
+                "value": "{{region.defaultIpProtection}}"
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultIpProtection"
+              }
             },
-            "role": {
+            "ip": {
               "type": "string",
-              "description": "bind your service account to this kubernetes default role",
-              "default": "view",
+              "description": "the white list of IP is whitespace",
+              "title": "Whitelist of IP",
+              "x-form": {
+                "value": "{{user.ip}}"
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{user.ip}}"
+              },
               "hidden": {
                 "value": false,
-                "path": "kubernetes/enabled"
-              },
-              "enum": [
-                "view",
-                "edit",
-                "admin"
-              ]
-            }
-          }
-        },
-        "git": {
-            "description": "Git user configuration",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Add git config inside your environment",
-                    "default": true
-                },
-                "name": {
-                    "type": "string",
-                    "description": "user name for git",
-                    "default": "",
-                    "x-form": {
-                        "value": "{{git.name}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{git.name}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "git/enabled"
-                    }
-                },
-                "email": {
-                    "type": "string",
-                    "description": "user email for git",
-                    "default": "",
-                    "x-form": {
-                        "value": "{{git.email}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{git.email}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "git/enabled"
-                    }
-                },
-                "cache": {
-                    "type": "string",
-                    "description": "duration in seconds of the credentials cache duration",
-                    "default": "",
-                    "x-form": {
-                        "value": "{{git.credentials_cache_duration}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "git/enabled"
-                    }
-                },
-                "token": {
-                    "type": "string",
-                    "description": "personal access token",
-                    "default": "",
-                    "render": "password",
-                    "x-form": {
-                        "value": "{{git.token}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{git.token}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "git/enabled"
-                    }
-                },
-                "repository": {
-                    "type": "string",
-                    "description": "Repository url",
-                    "default": "",
-                    "x-form": {
-                        "value": "{{git.project}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{git.project}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "git/enabled"
-                    }
-                },
-                "branch": {
-                    "type": "string",
-                    "description": "Brach automatically checkout",
-                    "default": "",
-                    "hidden": {
-                        "value": "",
-                        "path": "git/repository"
-                    }
-                }
-            }
-        },
-        "vault": {
-            "description": "Configuration of vault client",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Add vault temporary identity inside your environment",
-                    "default": true
-                },
-                "token": {
-                    "description": "token vault",
-                    "type": "string",
-                    "render": "password",
-                    "x-form": {
-                        "value": "{{vault.VAULT_TOKEN}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "vault/enabled"
-                    }
-                },
-                "url": {
-                    "description": "url of vault server",
-                    "type": "string",
-                    "x-form": {
-                        "value": "{{vault.VAULT_ADDR}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "vault/enabled"
-                    }
-                },
-                "mount": {
-                    "description": "mount of the v2 secret engine",
-                    "type": "string",
-                    "x-form": {
-                        "value": "{{vault.VAULT_MOUNT}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "vault/enabled"
-                    }
-                },
-                "directory": {
-                    "description": "top level directory",
-                    "type": "string",
-                    "x-form": {
-                        "value": "{{vault.VAULT_TOP_DIR}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "vault/enabled"
-                    }
-                },
-                "secret": {
-                    "description": "the path of the secret to convert into a list of environment variables",
-                    "type": "string",
-                    "default": "",
-                    "hidden": {
-                        "value": false,
-                        "path": "vault/enabled"
-                    }
-                }
-            }
-        },
-        "s3": {
-            "description": "Configuration of temporary identity",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Add S3 temporary identity inside your environment",
-                    "default": true
-                },
-                "accessKeyId": {
-                    "description": "AWS Access Key",
-                    "type": "string",
-                    "x-form": {
-                        "value": "{{s3.AWS_ACCESS_KEY_ID}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{s3.AWS_ACCESS_KEY_ID}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "s3/enabled"
-                    }
-                },
-                "endpoint": {
-                    "description": "AWS S3 Endpoint",
-                    "type": "string",
-                    "x-form": {
-                        "value": "{{s3.AWS_S3_ENDPOINT}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "s3/enabled"
-                    }
-                },
-                "defaultRegion": {
-                    "description": "AWS S3 default region",
-                    "type": "string",
-                    "x-form": {
-                        "value": "{{s3.AWS_DEFAULT_REGION}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "s3/enabled"
-                    }
-                },
-                "secretAccessKey": {
-                    "description": "AWS S3 secret access key",
-                    "type": "string",
-                    "render": "password",
-                    "x-form": {
-                        "value": "{{s3.AWS_SECRET_ACCESS_KEY}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "s3/enabled"
-                    }
-                },
-                "sessionToken": {
-                    "description": "AWS S3 session Token",
-                    "type": "string",
-                    "render": "password",
-                    "x-form": {
-                        "value": "{{s3.AWS_SESSION_TOKEN}}"
-                    },
-                    "x-onyxia": {
-                        "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
-                    },
-                    "hidden": {
-                        "value": false,
-                        "path": "s3/enabled"
-                    }
-                }
-            }
-        },
-        "ingress": {
-            "type": "object",
-            "form": true,
-            "title": "Ingress Details",
-            "properties": {
-                "enabled": {
-                    "description": "Enable Ingress",
-                    "type": "boolean",
-                    "default": true,
-                    "x-onyxia": {
-                        "hidden": true,
-                        "overwriteDefaultWith": "k8s.ingress"
-                    }
-                },
-                "hostname": {
-                    "type": "string",
-                    "form": true,
-                    "title": "Hostname",
-                    "x-form": {
-                        "hidden": true,
-                        "value": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
-                    },
-                    "x-onyxia": {
-                        "hidden": true,
-                        "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
-                    }
-                },
-                "userHostname": {
-                  "type": "string",
-                  "form": true,
-                  "title": "Hostname",
-                  "x-form": {
-                    "hidden": true,
-                    "value": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
-                  },
-                  "x-onyxia": {
-                      "hidden": true,
-                      "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
-                  }
-                },
-                "ingressClassName": {
-                    "type": "string",
-                    "form": true,
-                    "title": "ingressClassName",
-                    "default": "",
-                    "x-form": {
-                        "hidden": true,
-                        "value": "{{k8s.ingressClassName}}"
-                    },
-                    "x-onyxia": {
-                        "hidden": true,
-                        "overwriteDefaultWith": "{{k8s.ingressClassName}}"
-                    }
-                }
-            }
-        },
-        "route": {
-            "type": "object",
-            "form": true,
-            "title": "Route details",
-            "properties": {
-                "enabled": {
-                    "description": "Enable route",
-                    "type": "boolean",
-                    "default": false,
-                    "x-onyxia": {
-                        "hidden": true,
-                        "overwriteDefaultWith": "k8s.route"
-                    }
-                },
-                "hostname": {
-                    "type": "string",
-                    "form": true,
-                    "title": "Hostname",
-                    "x-onyxia": {
-                        "hidden": true,
-                        "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
-                    }
-                },
-                "userHostname": {
-                    "type": "string",
-                    "form": true,
-                    "title": "Hostname",
-                    "x-onyxia": {
-                        "hidden": true,
-                        "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
-                    }
-                }
-            }
-        },
-        "networking": {
-            "type": "object",
-            "form": true,
-            "title": "Networking detail",
-            "properties": {
-              "user": {
-                "type": "object",
-                "description": "user defined port",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean",
-                    "title": "Enable a custom service port",
-                    "description": "Enable a custom service port",
-                    "default": false
-                  },
-                  "port": {
-                    "type": "integer",
-                    "description": "port of the custom service",
-                    "title": "Custom service port",
-                    "hidden": {
-                      "value": false,
-                      "path": "networking/user/enabled"
-                    },   
-                    "default": 5000
-                  }
-                }
-              }
-            }
-        },
-        "init": {
-            "description": "Init parameters",
-            "type": "object",
-            "properties": {
-              "regionInit": {
-                "type": "string",
-                "description": "region initialization script",
-                "default": "",
-                "x-form": {
-                  "hidden": true,
-                  "value": "{{k8s.initScriptUrl}}"
-                },
-                "x-onyxia": {
-                  "hidden": true,
-                  "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
-                }
-              },
-              "personalInit": {
-                "type": "string",
-                "description": "user initialization script",
-                "default": ""
-              },
-              "personalInitArgs": {
-                "type": "string",
-                "description": "args for user initialization script",
-                "default": ""
+                "path": "security/allowlist/enabled"
               }
             }
           }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "description": "Define access policy to the service",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable network policy",
+              "description": "Only pod from the same namespace will be allowed",
+              "default": true,
+              "x-form": {
+                "value": "{{region.defaultNetworkPolicy}}"
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "type": "array",
+              "description": "Array of source allowed to have network access to your service",
+              "default": [],
+              "x-form": {
+                "hidden": true,
+                "value": "{{region.from}}"
+              },
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "description": "configuration of your kubernetes access",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "allow your service to access your namespace ressources",
+          "default": true
+        },
+        "role": {
+          "type": "string",
+          "description": "bind your service account to this kubernetes default role",
+          "default": "view",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "enum": [
+            "view",
+            "edit",
+            "admin"
+          ]
+        }
+      }
+    },
+    "git": {
+      "description": "Git user configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Add git config inside your environment",
+          "default": true
+        },
+        "name": {
+          "type": "string",
+          "description": "user name for git",
+          "default": "",
+          "x-form": {
+            "value": "{{git.name}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "git/enabled"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "user email for git",
+          "default": "",
+          "x-form": {
+            "value": "{{git.email}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "git/enabled"
+          }
+        },
+        "cache": {
+          "type": "string",
+          "description": "duration in seconds of the credentials cache duration",
+          "default": "",
+          "x-form": {
+            "value": "{{git.credentials_cache_duration}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "git/enabled"
+          }
+        },
+        "token": {
+          "type": "string",
+          "description": "personal access token",
+          "default": "",
+          "render": "password",
+          "x-form": {
+            "value": "{{git.token}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "git/enabled"
+          }
+        },
+        "repository": {
+          "type": "string",
+          "description": "Repository url",
+          "default": "",
+          "x-form": {
+            "value": "{{git.project}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "git/enabled"
+          }
+        },
+        "branch": {
+          "type": "string",
+          "description": "Brach automatically checkout",
+          "default": "",
+          "hidden": {
+            "value": "",
+            "path": "git/repository"
+          }
+        }
+      }
+    },
+    "vault": {
+      "description": "Configuration of vault client",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Add vault temporary identity inside your environment",
+          "default": true
+        },
+        "token": {
+          "description": "token vault",
+          "type": "string",
+          "render": "password",
+          "x-form": {
+            "value": "{{vault.VAULT_TOKEN}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "vault/enabled"
+          }
+        },
+        "url": {
+          "description": "url of vault server",
+          "type": "string",
+          "x-form": {
+            "value": "{{vault.VAULT_ADDR}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "vault/enabled"
+          }
+        },
+        "mount": {
+          "description": "mount of the v2 secret engine",
+          "type": "string",
+          "x-form": {
+            "value": "{{vault.VAULT_MOUNT}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "vault/enabled"
+          }
+        },
+        "directory": {
+          "description": "top level directory",
+          "type": "string",
+          "x-form": {
+            "value": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "vault/enabled"
+          }
+        },
+        "secret": {
+          "description": "the path of the secret to convert into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "vault/enabled"
+          }
+        }
+      }
+    },
+    "s3": {
+      "description": "Configuration of temporary identity",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Add S3 temporary identity inside your environment",
+          "default": true
+        },
+        "accessKeyId": {
+          "description": "AWS Access Key",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_ACCESS_KEY_ID}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_ACCESS_KEY_ID}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        },
+        "endpoint": {
+          "description": "AWS S3 Endpoint",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        },
+        "defaultRegion": {
+          "description": "AWS S3 default region",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        },
+        "secretAccessKey": {
+          "description": "AWS S3 secret access key",
+          "type": "string",
+          "render": "password",
+          "x-form": {
+            "value": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        },
+        "sessionToken": {
+          "description": "AWS S3 session Token",
+          "type": "string",
+          "render": "password",
+          "x-form": {
+            "value": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress Details",
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-form": {
+            "hidden": true,
+            "value": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          },
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-form": {
+            "hidden": true,
+            "value": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          },
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-form": {
+            "hidden": true,
+            "value": "{{k8s.ingressClassName}}"
+          },
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "networking": {
+      "type": "object",
+      "form": true,
+      "title": "Networking detail",
+      "properties": {
+        "user": {
+          "type": "object",
+          "description": "user defined port",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable a custom service port",
+              "description": "Enable a custom service port",
+              "default": false
+            },
+            "port": {
+              "type": "integer",
+              "description": "port of the custom service",
+              "title": "Custom service port",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            }
+          }
+        }
+      }
+    },
+    "init": {
+      "description": "Init parameters",
+      "type": "object",
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-form": {
+            "hidden": true,
+            "value": "{{k8s.initScriptUrl}}"
+          },
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "personalInit": {
+          "type": "string",
+          "description": "user initialization script",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "type": "string",
+          "description": "args for user initialization script",
+          "default": ""
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
     }
+  }
 }

--- a/charts/jupyter-r/values.schema.json
+++ b/charts/jupyter-r/values.schema.json
@@ -24,15 +24,15 @@
               "description": "supported versions",
               "type": "string",
               "enum": [
-                "inseefrlab/onyxia-jupyter-r:r4.2.3",
-                "inseefrlab/onyxia-jupyter-r:r4.1.2"
+                "inseefrlab/onyxia-jupyter-r:r4.2.1",
+                "inseefrlab/onyxia-jupyter-r:r4.1.3"
               ],
               "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
               "hidden": {
                 "value": true,
                 "path": "service/image/custom/enabled"
               },
-              "default": "inseefrlab/onyxia-jupyter-r:r4.2.3"
+              "default": "inseefrlab/onyxia-jupyter-r:r4.2.1"
             },
             "custom": {
               "description": "use a custom jupyter docker image",
@@ -47,7 +47,7 @@
                 "version": {
                   "description": "jupyter unsupported version",
                   "type": "string",
-                  "default": "inseefrlab/onyxia-jupyter-r:r4.2.3",
+                  "default": "inseefrlab/onyxia-jupyter-r:r4.2.1",
                   "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                   "hidden": {
                     "value": false,

--- a/charts/jupyter-r/values.yaml
+++ b/charts/jupyter-r/values.yaml
@@ -67,8 +67,27 @@ git:
 
 repository:
   configMapName: ""
-  rRepository: ""
+  pipRepository: ""
+  condaRepository: ""
   
+#active ou non la recherche d'un hiveMetastore dans le namespace
+# see configmap-hive.yaml et helpers template
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+
+hive:
+  configMapName: ""
+
+mlflow:
+  configMapName: ""
+
+coresite:
+  configMapName: ""
+  
+metaflow:
+  configMapName: ""
   # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
@@ -118,7 +137,7 @@ networking:
 ingress:
   enabled: true
   tls: true
-  ingressClassName: ""  
+  ingressClassName: ""   
   annotations: []
     # kubernetes.io/tls-acme: "true"
   hostname: chart-example.local
@@ -154,7 +173,7 @@ resources: {}
   #   memory: 128Mi
 
 persistence:
-  enabled: true
+  enabled: false
   ## database data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/charts/jupyter-tensorflow-gpu/Chart.yaml
+++ b/charts/jupyter-tensorflow-gpu/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.4
+version: 1.6.5
 dependencies:
 - name: library-chart
   version: 1.3.2

--- a/charts/jupyter-tensorflow-gpu/Chart.yaml
+++ b/charts/jupyter-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.7
+version: 1.6.8
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow-gpu/Chart.yaml
+++ b/charts/jupyter-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.5
+version: 1.6.6
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow-gpu/Chart.yaml
+++ b/charts/jupyter-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.6
+version: 1.6.7
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow-gpu/Chart.yaml
+++ b/charts/jupyter-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.3
+version: 1.6.4
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow/Chart.yaml
+++ b/charts/jupyter-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.7
+version: 1.6.8
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow/Chart.yaml
+++ b/charts/jupyter-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.5
+version: 1.6.6
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow/Chart.yaml
+++ b/charts/jupyter-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.3
+version: 1.6.4
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow/Chart.yaml
+++ b/charts/jupyter-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.6
+version: 1.6.7
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-tensorflow/Chart.yaml
+++ b/charts/jupyter-tensorflow/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.4
+version: 1.6.5
 dependencies:
 - name: library-chart
   version: 1.3.2

--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.3.3
+version: 1.3.4
 type: library

--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.3.1
+version: 1.3.2
 type: library

--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.3.4
+version: 1.3.5
 type: library

--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.3.2
+version: 1.3.3
 type: library

--- a/charts/library-chart/templates/_configmap.tpl
+++ b/charts/library-chart/templates/_configmap.tpl
@@ -228,6 +228,7 @@ metadata:
   labels:
     {{- include "library-chart.labels" $context | nindent 4 }}
 data:
+  MLFLOW_S3_ENDPOINT_URL: "https://{{ .Values.s3.endpoint }}/"
   MLFLOW_TRACKING_URI: {{ printf "%s" $uri }}
 {{- end }}
 {{- end }}

--- a/charts/library-chart/templates/_configmap.tpl
+++ b/charts/library-chart/templates/_configmap.tpl
@@ -269,6 +269,44 @@ metadata:
 data:
   spark-defaults.conf: |
     {{- include "library-chart.sparkConf" . | nindent 4 }}
+    {{- if .Values.repository.mavenRepository -}}
+    {{ printf "spark.jars.ivySettings /opt/spark/conf/ivysettings.xml" }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+
+
+{{/* ConfigMap for Ivy Settings (custom maven repository for Spark) */}}
+{{- define "library-chart.ivySettings" -}}
+{{ printf "<ivysettings>" }}
+{{ printf "<settings defaultResolver=\"custom_maven_repository\"/>" | indent 4 }}
+{{ printf "<resolvers>" | indent 4 }}
+{{ printf "<ibiblio name=\"custom_maven_repository\" m2compatible=\"true\" root=\"%s\"/>"  .Values.repository.mavenRepository | indent 8 }}
+{{ printf "</resolvers>" | indent 4 }}
+{{ printf "</ivysettings>" }}
+{{- end -}}
+
+{{/* Create the name of the config map Ivy Settings to use */}}
+{{- define "library-chart.configMapNameIvySettings" -}}
+{{- if and (.Values.spark.default) (.Values.repository.mavenRepository) }}
+{{- $name:= (printf "%s-configmapivysettings" (include "library-chart.fullname" .) )  }}
+{{- $name }}
+{{- end }}
+{{- end }}
+
+{{/* Template to generate a ConfigMap for Ivy Settings */}}
+{{- define "library-chart.configMapIvySettings" -}}
+{{- if and (.Values.spark.default) (.Values.repository.mavenRepository) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "library-chart.configMapNameIvySettings" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+data:
+  ivysettings.xml: |
+    {{- include "library-chart.ivySettings" . | nindent 4 }}
 {{- end }}
 {{- end }}
 

--- a/charts/library-chart/templates/_configmap.tpl
+++ b/charts/library-chart/templates/_configmap.tpl
@@ -213,7 +213,7 @@ data:
 {{- default $name .Values.mlflow.configMapName }}
 {{- end }}
 
-{{/* ConfigMap for Hive Metastore */}}
+{{/* ConfigMap for MLFlow */}}
 {{- define "library-chart.configMapMLFlow" -}}
 {{- $context:= . -}}
 {{- if .Values.discovery.mlflow -}}
@@ -228,9 +228,6 @@ metadata:
   labels:
     {{- include "library-chart.labels" $context | nindent 4 }}
 data:
-  {{- if .Values.s3.enabled -}}
-  MLFLOW_S3_ENDPOINT_URL: "https://{{ .Values.s3.endpoint }}/"
-  {{- end }}
   MLFLOW_TRACKING_URI: {{ printf "%s" $uri }}
 {{- end }}
 {{- end }}
@@ -240,12 +237,12 @@ data:
 
 {{/* ConfigMap for SparkConf Metastore */}}
 {{- define "library-chart.sparkConf" -}}
-{{- $contexte:= .}}
+{{- $context:= .}}
 {{- range $key, $value := default dict .Values.spark.config }}
-{{- printf "%s %s\n" $key  (tpl $value  $contexte)}}
+{{- printf "%s %s\n" $key  (tpl $value  $context)}}
 {{- end }}
 {{- range $key, $value := default dict .Values.spark.userConfig }}
-{{- printf "%s %s\n" $key  (tpl $value  $contexte)}}
+{{- printf "%s %s\n" $key  (tpl $value  $context)}}
 {{- end }}
 {{- end }}
 

--- a/charts/library-chart/templates/_configmap.tpl
+++ b/charts/library-chart/templates/_configmap.tpl
@@ -228,6 +228,7 @@ metadata:
   labels:
     {{- include "library-chart.labels" $context | nindent 4 }}
 data:
+  MLFLOW_S3_ENDPOINT_URL: "https://minio.lab.sspcloud.fr"
   MLFLOW_TRACKING_URI: {{ printf "%s" $uri }}
 {{- end }}
 {{- end }}

--- a/charts/library-chart/templates/_configmap.tpl
+++ b/charts/library-chart/templates/_configmap.tpl
@@ -228,7 +228,9 @@ metadata:
   labels:
     {{- include "library-chart.labels" $context | nindent 4 }}
 data:
+  {{- if .Values.s3.enabled -}}
   MLFLOW_S3_ENDPOINT_URL: "https://{{ .Values.s3.endpoint }}/"
+  {{- end }}
   MLFLOW_TRACKING_URI: {{ printf "%s" $uri }}
 {{- end }}
 {{- end }}

--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.7
+version: 1.6.8
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.5
+version: 1.6.6
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.6
+version: 1.6.7
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.6.4
+version: 1.6.5
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,9 +23,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.6
+version: 1.5.7
 
 dependencies:
   - name: library-chart
-    version: 1.3.3
+    version: 1.3.4
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,9 +23,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.5
+version: 1.5.6
 
 dependencies:
   - name: library-chart
-    version: 1.3.2
+    version: 1.3.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.4
+version: 1.5.5
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,9 +23,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.3
+version: 1.5.4
 
 dependencies:
   - name: library-chart
-    version: 1.3.1
+    version: 1.3.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,9 +23,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.7
+version: 1.5.8
 
 dependencies:
   - name: library-chart
-    version: 1.3.4
+    version: 1.3.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/values.schema.json
+++ b/charts/rstudio-sparkr/values.schema.json
@@ -20,15 +20,15 @@
                         "description": "supported versions",
                         "type": "string",
                         "enum": [
-                            "inseefrlab/onyxia-rstudio-sparkr:r4.2.3-spark3.3.0",
-                            "inseefrlab/onyxia-rstudio-sparkr:r4.1.2-spark3.3.0"
+                            "inseefrlab/onyxia-rstudio-sparkr:r4.2.1-spark3.3.0",
+                            "inseefrlab/onyxia-rstudio-sparkr:r4.1.3-spark3.3.0"
                                 ],
                         "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                         "hidden": {
                             "value": true,
                             "path": "service/image/custom/enabled"
                         },
-                        "default": "inseefrlab/onyxia-rstudio-sparkr:r4.2.3-spark3.3.0"
+                        "default": "inseefrlab/onyxia-rstudio-sparkr:r4.2.1-spark3.3.0"
                       },
                       "custom" : {
                         "description": "use a custom RStudio docker image",
@@ -43,7 +43,7 @@
                           "version": {
                             "description": "RStudio unsupported version",
                             "type": "string",
-                            "default": "inseefrlab/onyxia-rstudio-sparkr:r4.2.3-spark3.3.0",
+                            "default": "inseefrlab/onyxia-rstudio-sparkr:r4.2.1-spark3.3.0",
                             "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                             "hidden": {
                                 "value": false,

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.7
+version: 1.6.8
 
 dependencies:
   - name: library-chart
-    version: 1.3.4
+    version: 1.3.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.6
+version: 1.6.7
 
 dependencies:
   - name: library-chart
-    version: 1.3.3
+    version: 1.3.4
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.5
+version: 1.6.6
 
 dependencies:
   - name: library-chart
-    version: 1.3.2
+    version: 1.3.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.4
+version: 1.6.5
 
 dependencies:
   - name: library-chart
-    version: 1.3.1
+    version: 1.3.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python-gpu/Chart.yaml
+++ b/charts/vscode-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.5
+version: 1.4.6
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python-gpu/Chart.yaml
+++ b/charts/vscode-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.2
+version: 1.4.3
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python-gpu/Chart.yaml
+++ b/charts/vscode-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.4
+version: 1.4.5
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python-gpu/Chart.yaml
+++ b/charts/vscode-python-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.3
+version: 1.4.4
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.5
+version: 1.4.6
 
 dependencies:
   - name: library-chart
-    version: 1.3.4
+    version: 1.3.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.4
+version: 1.4.5
 
 dependencies:
   - name: library-chart
-    version: 1.3.3
+    version: 1.3.4
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.2
+version: 1.4.3
 
 dependencies:
   - name: library-chart
-    version: 1.3.1
+    version: 1.3.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.3
+version: 1.4.4
 
 dependencies:
   - name: library-chart
-    version: 1.3.2
+    version: 1.3.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch-gpu/Chart.yaml
+++ b/charts/vscode-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.5
+version: 1.4.6
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch-gpu/Chart.yaml
+++ b/charts/vscode-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.2
+version: 1.4.3
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch-gpu/Chart.yaml
+++ b/charts/vscode-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.4
+version: 1.4.5
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch-gpu/Chart.yaml
+++ b/charts/vscode-pytorch-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.3
+version: 1.4.4
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch/Chart.yaml
+++ b/charts/vscode-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.5
+version: 1.4.6
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch/Chart.yaml
+++ b/charts/vscode-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.3
+version: 1.4.4
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch/Chart.yaml
+++ b/charts/vscode-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.4
+version: 1.4.5
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pytorch/Chart.yaml
+++ b/charts/vscode-pytorch/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.2
+version: 1.4.3
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-r-python-julia/Chart.yaml
+++ b/charts/vscode-r-python-julia/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.5
+version: 1.4.6
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-r-python-julia/Chart.yaml
+++ b/charts/vscode-r-python-julia/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.3
+version: 1.4.4
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-r-python-julia/Chart.yaml
+++ b/charts/vscode-r-python-julia/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.4
+version: 1.4.5
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-r-python-julia/Chart.yaml
+++ b/charts/vscode-r-python-julia/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.2
+version: 1.4.3
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow-gpu/Chart.yaml
+++ b/charts/vscode-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.5
+version: 1.4.6
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow-gpu/Chart.yaml
+++ b/charts/vscode-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.2
+version: 1.4.3
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow-gpu/Chart.yaml
+++ b/charts/vscode-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.4
+version: 1.4.5
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow-gpu/Chart.yaml
+++ b/charts/vscode-tensorflow-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.3
+version: 1.4.4
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow/Chart.yaml
+++ b/charts/vscode-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.5
+version: 1.4.6
 dependencies:
 - name: library-chart
-  version: 1.3.4
+  version: 1.3.5
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow/Chart.yaml
+++ b/charts/vscode-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.3
+version: 1.4.4
 dependencies:
 - name: library-chart
-  version: 1.3.2
+  version: 1.3.3
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow/Chart.yaml
+++ b/charts/vscode-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.4
+version: 1.4.5
 dependencies:
 - name: library-chart
-  version: 1.3.3
+  version: 1.3.4
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-tensorflow/Chart.yaml
+++ b/charts/vscode-tensorflow/Chart.yaml
@@ -10,8 +10,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.4.2
+version: 1.4.3
 dependencies:
 - name: library-chart
-  version: 1.3.1
+  version: 1.3.2
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/utils/charts-inheritance.yaml
+++ b/utils/charts-inheritance.yaml
@@ -8,8 +8,8 @@ jupyter-python:
   jupyter-r:
     description: The JupyterLab IDE with R and a collection of standard data science packages.
     images:
-      - inseefrlab/onyxia-jupyter-r:r4.2.3
-      - inseefrlab/onyxia-jupyter-r:r4.1.2
+      - inseefrlab/onyxia-jupyter-r:r4.2.1
+      - inseefrlab/onyxia-jupyter-r:r4.1.3
   jupyter-tensorflow:
     description: The JupyterLab IDE with Python and the deep-learning framework TensorFlow.
   jupyter-tensorflow-gpu:

--- a/utils/charts-inheritance.yaml
+++ b/utils/charts-inheritance.yaml
@@ -5,6 +5,11 @@ jupyter-python:
     description: The JupyterLab IDE with Python and the deep-learning framework PyTorch.
   jupyter-pytorch-gpu:
     description: The JupyterLab IDE with Python and the deep-learning framework PyTorch, with GPU support.
+  jupyter-r:
+    description: The JupyterLab IDE with R and a collection of standard data science packages.
+    images:
+      - inseefrlab/onyxia-jupyter-r:r4.2.3
+      - inseefrlab/onyxia-jupyter-r:r4.1.2
   jupyter-tensorflow:
     description: The JupyterLab IDE with Python and the deep-learning framework TensorFlow.
   jupyter-tensorflow-gpu:
@@ -17,6 +22,8 @@ jupyter-pyspark:
 rstudio:
   rstudio-gpu:
     description: The RStudio IDE with a collection of standard data science packages, with GPU support.
+
+rstudio-sparkr: []
 
 vscode-python:
   vscode-python-gpu:

--- a/utils/generate-children-charts.py
+++ b/utils/generate-children-charts.py
@@ -8,7 +8,7 @@ import yaml
 
 PROJECT_PATH = Path(__file__).resolve().parents[1]
 
-with open("charts-inheritance.yaml", "r") as file_in:
+with open(PROJECT_PATH / "utils" / "charts-inheritance.yaml", "r") as file_in:
     parameters = yaml.safe_load(file_in)
 
 for parent in parameters:

--- a/utils/generate-children-charts.py
+++ b/utils/generate-children-charts.py
@@ -8,7 +8,7 @@ import yaml
 
 PROJECT_PATH = Path(__file__).resolve().parents[1]
 
-with open(PROJECT_PATH / "charts" / "children.yaml", "r") as file_in:
+with open("charts-inheritance.yaml", "r") as file_in:
     parameters = yaml.safe_load(file_in)
 
 for parent in parameters:


### PR DESCRIPTION
Spark workloads may require the download of third-party Java dependencies (eg : PostgreSQL JDBC driver).

This PR is part one of a set of changes aiming at allowing an end-user to configure a specific Maven repository for such dependency resolution, instead of using the default (Maven Central) - which is not usable in offline environments.

This first part focuses on `library-chart` only, the second will update the actual Spark based charts (jupyter-pyspark, jupyter-pyspark-gpu and rstudio-sparkr).

For some implementation details : 

- Spark uses Ivy for dependency resolution, and two parameters to change this, `spark.jars.ivySettings` and `spark.jars.repositories`.
- The latter only seems to append new repositories for dependency resolution, in other words the default is used first. In an offline environment, this means having to wait for a (long) timeout before actually being able to download dependencies.
- The former allows to replace the Ivy configuration file altogether. This is the approach used by this PR : 
  - First, a config map representing a custom `ivysettings.xml` file is "templated" here - it will be used in the actual Spark charts (jupyter-pyspark et al).
  - The pre-existing config map managing the `spark-defaults.conf` file is extended to add a new parameter pointing to the custom maven repository, if said repository is configured.
  - This custom repository is configured in the `values.yaml` files of the actual Spark based charts with a `repository.mavenRepository` key, that will sit next to the other "repository" parameters (eg : `repository.pipRepository`, ...). This key will be added in part two (another PR I will created after this one is accepted).

On a side note, this way of mananing repositories is different than the one used for R, pip and conda repositories. For these three, it was possible to use the `/opt/onyxia-init.sh` file to react to environment variables and create/append the necessary configuration. But in the case of Spark, the target of the modification (the Spark configuration file `spark-defaults.conf`) is a mounted volume, which means it is not possible to append to it, hence this whole Helm based implementation.