### PR TITLE
library-chart : add CM for ivysettings.xml

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.3.5
+version: 1.3.6
 type: library

--- a/charts/library-chart/templates/_configmap.tpl
+++ b/charts/library-chart/templates/_configmap.tpl
@@ -269,6 +269,44 @@ metadata:
 data:
   spark-defaults.conf: |
     {{- include "library-chart.sparkConf" . | nindent 4 }}
+    {{- if .Values.repository.mavenRepository -}}
+    {{ printf "spark.jars.ivySettings /opt/spark/conf/ivysettings.xml" }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+
+
+{{/* ConfigMap for Ivy Settings (custom maven repository for Spark) */}}
+{{- define "library-chart.ivySettings" -}}
+{{ printf "<ivysettings>" }}
+{{ printf "<settings defaultResolver=\"custom_maven_repository\"/>" | indent 4 }}
+{{ printf "<resolvers>" | indent 4 }}
+{{ printf "<ibiblio name=\"custom_maven_repository\" m2compatible=\"true\" root=\"%s\"/>"  .Values.repository.mavenRepository | indent 8 }}
+{{ printf "</resolvers>" | indent 4 }}
+{{ printf "</ivysettings>" }}
+{{- end -}}
+
+{{/* Create the name of the config map Ivy Settings to use */}}
+{{- define "library-chart.configMapNameIvySettings" -}}
+{{- if and (.Values.spark.default) (.Values.repository.mavenRepository) }}
+{{- $name:= (printf "%s-configmapivysettings" (include "library-chart.fullname" .) )  }}
+{{- $name }}
+{{- end }}
+{{- end }}
+
+{{/* Template to generate a ConfigMap for Ivy Settings */}}
+{{- define "library-chart.configMapIvySettings" -}}
+{{- if and (.Values.spark.default) (.Values.repository.mavenRepository) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "library-chart.configMapNameIvySettings" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+data:
+  ivysettings.xml: |
+    {{- include "library-chart.ivySettings" . | nindent 4 }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
*This PR is a replacement for #49, which I sabotaged with a bad rebase - I'll just copy the description from that one below.*

---

Spark workloads may require the download of third-party Java dependencies (eg : PostgreSQL JDBC driver).

This PR is part one of a set of changes aiming at allowing an end-user to configure a specific Maven repository for such dependency resolution, instead of using the default (Maven Central) - which is not usable in offline environments.

This first part focuses on `library-chart` only, the second will update the actual Spark based charts (jupyter-pyspark, jupyter-pyspark-gpu and rstudio-sparkr).

For some implementation details : 

- Spark uses Ivy for dependency resolution, and two parameters to change this, `spark.jars.ivySettings` and `spark.jars.repositories`.
- The latter only seems to append new repositories for dependency resolution, in other words the default is used first. In an offline environment, this means having to wait for a (long) timeout before actually being able to download dependencies.
- The former allows to replace the Ivy configuration file altogether. This is the approach used by this PR : 
  - First, a config map representing a custom `ivysettings.xml` file is "templated" here - it will be used in the actual Spark charts (jupyter-pyspark et al).
  - The pre-existing config map managing the `spark-defaults.conf` file is extended to add a new parameter pointing to the custom maven repository, if said repository is configured.
  - This custom repository is configured in the `values.yaml` files of the actual Spark based charts with a `repository.mavenRepository` key, that will sit next to the other "repository" parameters (eg : `repository.pipRepository`, ...). This key will be added in part two (another PR I will created after this one is accepted).

On a side note, this way of mananing repositories is different than the one used for R, pip and conda repositories. For these three, it was possible to use the `/opt/onyxia-init.sh` file to react to environment variables and create/append the necessary configuration. But in the case of Spark, the target of the modification (the Spark configuration file `spark-defaults.conf`) is a mounted volume, which means it is not possible to append to it, hence this whole Helm based implementation.