### PR TITLE
Use `packageManagerUrl` from Onyxia region when available

### DIFF
--- a/charts/rstudio-gpu/Chart.yaml
+++ b/charts/rstudio-gpu/Chart.yaml
@@ -11,8 +11,8 @@ sources:
 - https://github.com/InseeFrLab/images-datascience
 - https://github.com/InseeFrLab/helm-charts-interactive-services
 type: application
-version: 1.13.1
+version: 1.14.0
 dependencies:
 - name: library-chart
-  version: 1.3.15
+  version: 1.4.0
   repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-gpu/README.md
+++ b/charts/rstudio-gpu/README.md
@@ -64,6 +64,7 @@ The RStudio IDE with a collection of standard data science packages, with GPU su
 | podSecurityContext.fsGroup | int | `100` |  |
 | replicaCount | int | `1` |  |
 | repository.configMapName | string | `""` |  |
+| repository.packageManagerUrl | string | `""` |  |
 | repository.rRepository | string | `""` |  |
 | resources | object | `{}` |  |
 | route.annotations | list | `[]` |  |

--- a/charts/rstudio-gpu/values.schema.json
+++ b/charts/rstudio-gpu/values.schema.json
@@ -720,6 +720,15 @@
             "hidden": true,
             "overwriteDefaultWith": "{{packageRepositoryInjection.cranProxyUrl}}"
           }
+        },
+        "packageManagerUrl": {
+          "type": "string",
+          "description": "Posit Package Manager URL",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.packageManagerUrl}}"
+          }
         }
       }
     },

--- a/charts/rstudio-gpu/values.yaml
+++ b/charts/rstudio-gpu/values.yaml
@@ -100,4 +100,5 @@ tolerations: []
 affinity: {}
 repository:
   configMapName: ''
+  packageManagerUrl: ''
   rRepository: ''

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,9 +23,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.0
+version: 1.13.0
 
 dependencies:
   - name: library-chart
-    version: 1.3.15
+    version: 1.4.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/README.md
+++ b/charts/rstudio-sparkr/README.md
@@ -69,6 +69,7 @@ The RStudio IDE with a collection of standard data science packages. It includes
 | replicaCount | int | `1` |  |
 | repository.configMapName | string | `""` |  |
 | repository.mavenRepository | string | `""` |  |
+| repository.packageManagerUrl | string | `""` |  |
 | repository.rRepository | string | `""` |  |
 | resources | object | `{}` |  |
 | route.annotations | list | `[]` |  |

--- a/charts/rstudio-sparkr/values.schema.json
+++ b/charts/rstudio-sparkr/values.schema.json
@@ -740,6 +740,15 @@
                     "hidden": true,
                     "overwriteDefaultWith": "{{packageRepositoryInjection.cranProxyUrl}}"
                   }
+                },
+                "packageManagerUrl": {
+                  "type": "string",
+                  "description": "Posit Package Manager URL",
+                  "default": "",
+                  "x-onyxia": {
+                    "hidden": true,
+                    "overwriteDefaultWith": "{{packageRepositoryInjection.packageManagerUrl}}"
+                  }
                 }
               }
         },

--- a/charts/rstudio-sparkr/values.yaml
+++ b/charts/rstudio-sparkr/values.yaml
@@ -210,5 +210,6 @@ affinity: {}
 
 repository:
   configMapName: ""
+  packageManagerUrl: ""
   rRepository: ""
   mavenRepository: ""

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.13.1
+version: 1.14.0
 
 dependencies:
   - name: library-chart
-    version: 1.3.15
+    version: 1.4.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/README.md
+++ b/charts/rstudio/README.md
@@ -64,6 +64,7 @@ The RStudio IDE with a collection of standard data science packages.
 | podSecurityContext.fsGroup | int | `100` |  |
 | replicaCount | int | `1` |  |
 | repository.configMapName | string | `""` |  |
+| repository.packageManagerUrl | string | `""` |  |
 | repository.rRepository | string | `""` |  |
 | resources | object | `{}` |  |
 | route.annotations | list | `[]` |  |

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -703,6 +703,15 @@
                   "hidden": true,
                   "overwriteDefaultWith": "{{packageRepositoryInjection.cranProxyUrl}}"
                 }
+              },
+              "packageManagerUrl": {
+                "type": "string",
+                "description": "Posit Package Manager URL",
+                "default": "",
+                "x-onyxia": {
+                  "hidden": true,
+                  "overwriteDefaultWith": "{{packageRepositoryInjection.packageManagerUrl}}"
+                }
               }
             }
         },

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -176,4 +176,5 @@ affinity: {}
 
 repository:
   configMapName: ""
+  packageManagerUrl: ""
   rRepository: ""


### PR DESCRIPTION
This actually contains the changes pushed in https://github.com/InseeFrLab/helm-charts-interactive-services/pull/76, but that one should be merged first, to allow the proper rebuild of library-chart with its new version. I'll rebase if Github finds a conflict. As such, leaving this as draft for now.

The change itself is mostly centered on the `values.schema.json` files to make use of `packageRepositoryInjection` and set the `repository.packageManagerUrl` parameter accordingly. This parameter (or rather, the environment variable it sets) is unused for now, I'll make another PR on the https://github.com/InseeFrLab/images-datascience repo for that.