### PR TITLE
RStudio Sparkr : split container and initContainer securityContext

### DIFF
--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.16
+version: 1.17.0
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio-sparkr/README.md
+++ b/charts/rstudio-sparkr/README.md
@@ -1,6 +1,6 @@
 # rstudio-sparkr
 
-![Version: 1.16.16](https://img.shields.io/badge/Version-1.16.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.17.0](https://img.shields.io/badge/Version-1.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 The RStudio IDE with a collection of standard data science packages. It includes SparkR, an R package that provides an interface to use Apache Spark from R.
 
@@ -51,6 +51,7 @@ The RStudio IDE with a collection of standard data science packages. It includes
 | init.personalInitArgs | string | `""` |  |
 | init.regionInit | string | `""` |  |
 | init.standardInitPath | string | `"/opt/onyxia-init.sh"` |  |
+| initSecurityContext | object | `{}` |  |
 | kubernetes.enable | bool | `true` |  |
 | kubernetes.role | string | `"view"` |  |
 | nameOverride | string | `""` |  |

--- a/charts/rstudio-sparkr/templates/statefulset.yaml
+++ b/charts/rstudio-sparkr/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
               cpu: 50m
               memory: 50Mi
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/rstudio-sparkr/values.yaml
+++ b/charts/rstudio-sparkr/values.yaml
@@ -126,6 +126,14 @@ podAnnotations: {}
 podSecurityContext:
   fsGroup: 100
 
+initSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
 securityContext: {}
   # capabilities:
   #   drop:

--- a/charts/rstudio-sparkr/values.yaml
+++ b/charts/rstudio-sparkr/values.yaml
@@ -126,7 +126,7 @@ podAnnotations: {}
 podSecurityContext:
   fsGroup: 100
 
-initSecurityContext: {}
+initContainerSecurityContext: {}
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION
Currently, the `make-secrets-writable` initContainer, and the "main" container in `rstudio-sparkr` Chart share the same security context. As the RStudio image needs to runAsRoot to work properly, this implies the initContainer image also runs as root, even though it's not strictly necessary.

This PR changes the StatefulSet template to have a dedicated parameter for the initContainer's security context, to allow reducing the privileges for the initContainer.

Ping @alexisdondon to make sure this is enough, and any other maintainer to review and check if this is acceptable.