### PR TITLE
feat: :sparkles: openshift compatibility

### DIFF
--- a/charts/jupyter-python/templates/role-binding-scc.yaml
+++ b/charts/jupyter-python/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -295,6 +295,30 @@
                 }
             }
         },
+        "openshiftSCC": {
+            "description": "configuration for openshift comptibility",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                "description": "enable rolebinding with openshift scc",
+                "type": "boolean",
+                "default": false,
+                "x-onyxia": {
+                    "hidden": true,
+                    "overwriteDefaultWith": "region.customValues.openshiftSCC.enabled"
+                    }
+                },
+                "scc": {
+                    "type": "string",
+                    "description": "name of scc for rolebinding",
+                    "default": "nonroot",
+                    "x-onyxia": {
+                        "hidden": true,
+                        "overwriteDefaultWith": "region.customValues.openshiftSCC.scc"
+                    }
+                }
+            }
+        },
         "git": {
             "description": "Git user configuration",
             "type": "object",

--- a/charts/jupyter-python/values.yaml
+++ b/charts/jupyter-python/values.yaml
@@ -110,6 +110,10 @@ kubernetes:
   enabled: false
   role: "view"
 
+openshiftSCC:
+  enabled: false
+  scc: nonroot
+
 podAnnotations: {}
 
 podSecurityContext:

--- a/charts/library-chart/templates/_role_binding_scc.tpl
+++ b/charts/library-chart/templates/_role_binding_scc.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Template to generate a RoleBinding to SCC */}}
+{{- define "library-chart.roleBindingSCC" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.openshiftSCC.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ include "library-chart.serviceAccountName" . }}-scc-{{ .Values.openshiftSCC.scc }}'
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ .Values.openshiftSCC.scc }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "library-chart.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Purpose

Add openshift compatibilty for helm charts repositories. 

## Notes
Currently changes are done only for `jupyter-python` for validating.

## Changes
- `charts/library-chart/` : add rolebindings with scc (default `nonroot`)
- `charts/jupyter-python/` : add `values.yaml` and `values.schema.json`. Enable this feature only on region configuration.