### PR TITLE
feat: :sparkles: ocp compatibility library chart

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.5.21
+version: 1.5.22
 type: library

--- a/charts/library-chart/templates/_role_binding.tpl
+++ b/charts/library-chart/templates/_role_binding.tpl
@@ -21,3 +21,26 @@ subjects:
 {{- end }}
 {{- end }}
 {{- end }}
+
+
+{{/* Template to generate a RoleBinding to SCC */}}
+{{- define "library-chart.roleBindingSCC" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.openshiftSCC.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ include "library-chart.serviceAccountName" . }}-scc-{{ .Values.openshiftSCC.scc }}'
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ .Values.openshiftSCC.scc }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "library-chart.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Purpose

Add openshift compatibilty for helm charts repositories. 

## Changes
- `charts/library-chart/` : add rolebindings with scc 