### PR TITLE
Dummy secret in unittest's kubernetesProvider

### DIFF
--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -2,6 +2,20 @@ suite: test deployment
 templates:
   - statefulset.yaml
   - secret-*.yaml
+# Dummy secret provided to avoid bug from empty lookups : https://github.com/helm-unittest/helm-unittest/issues/380
+kubernetesProvider:
+  scheme:
+    "v1/Secret":
+      gvr:
+        version:  "v1"
+        resource: "secrets"
+      namespaced: true
+  objects:
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: unittest
+        namespace: default
 tests:
   - it: should work
     asserts:


### PR DESCRIPTION
Provides a dummy secret in unittest's kubernetesProvider to avoid a known bug coming from empty lookups
https://github.com/helm-unittest/helm-unittest/issues/380

