### PR TITLE
[Python version update] Charts use the new python 3.12.5 images

### DIFF
--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -24,7 +24,7 @@
               "description": "supported versions",
               "type": "string",
               "listEnum": [
-                "inseefrlab/onyxia-jupyter-pyspark:py3.12.4-spark3.5.2",
+                "inseefrlab/onyxia-jupyter-pyspark:py3.12.5-spark3.5.2",
                 "inseefrlab/onyxia-jupyter-pyspark:py3.11.9-spark3.5.2"
               ],
               "render": "list",
@@ -32,7 +32,7 @@
                 "value": true,
                 "path": "service/image/custom/enabled"
               },
-              "default": "inseefrlab/onyxia-jupyter-pyspark:py3.12.4-spark3.5.2"
+              "default": "inseefrlab/onyxia-jupyter-pyspark:py3.12.5-spark3.5.2"
             },
             "custom": {
               "description": "use a custom jupyter docker image",
@@ -50,7 +50,7 @@
                 "version": {
                   "description": "jupyter unsupported version",
                   "type": "string",
-                  "default": "inseefrlab/onyxia-jupyter-pyspark:py3.12.4-spark3.5.2",
+                  "default": "inseefrlab/onyxia-jupyter-pyspark:py3.12.5-spark3.5.2",
                   "hidden": {
                     "value": false,
                     "path": "service/image/custom/enabled"

--- a/charts/jupyter-pyspark/values.yaml
+++ b/charts/jupyter-pyspark/values.yaml
@@ -4,11 +4,11 @@ global:
 
 service:
   image:
-    version: "inseefrlab/onyxia-jupyter-pyspark:py3.12.4-spark3.5.2"
+    version: "inseefrlab/onyxia-jupyter-pyspark:py3.12.5-spark3.5.2"
     pullPolicy: IfNotPresent
     custom:
       enabled: false
-      version: "inseefrlab/onyxia-jupyter-pyspark:py3.12.4-spark3.5.2"
+      version: "inseefrlab/onyxia-jupyter-pyspark:py3.12.5-spark3.5.2"
 
 spark:
   sparkui: false

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -24,7 +24,7 @@
                             "description": "supported versions",
                             "type": "string",
                             "listEnum": [
-                                "inseefrlab/onyxia-jupyter-python:py3.12.4",
+                                "inseefrlab/onyxia-jupyter-python:py3.12.5",
                                 "inseefrlab/onyxia-jupyter-python:py3.11.9"
                             ],
                             "render": "list",
@@ -32,7 +32,7 @@
                                 "value": true,
                                 "path": "service/image/custom/enabled"
                             },
-                            "default": "inseefrlab/onyxia-jupyter-python:py3.12.4"
+                            "default": "inseefrlab/onyxia-jupyter-python:py3.12.5"
                         },
                         "custom": {
                             "description": "use a custom jupyter docker image",
@@ -50,7 +50,7 @@
                                 "version": {
                                     "description": "jupyter unsupported version",
                                     "type": "string",
-                                    "default": "inseefrlab/onyxia-jupyter-python:py3.12.4",
+                                    "default": "inseefrlab/onyxia-jupyter-python:py3.12.5",
                                     "hidden": {
                                         "value": false,
                                         "path": "service/image/custom/enabled"

--- a/charts/jupyter-python/values.yaml
+++ b/charts/jupyter-python/values.yaml
@@ -4,11 +4,11 @@ global:
 
 service:
   image:
-    version: "inseefrlab/onyxia-jupyter-python:py3.12.4"
+    version: "inseefrlab/onyxia-jupyter-python:py3.12.5"
     pullPolicy: IfNotPresent
     custom:
       enabled: false
-      version: "inseefrlab/onyxia-jupyter-python:py3.12.4"
+      version: "inseefrlab/onyxia-jupyter-python:py3.12.5"
 
 security:
   password: "changeme"

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.6
+version: 2.0.7
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-pyspark/values.schema.json
+++ b/charts/vscode-pyspark/values.schema.json
@@ -24,7 +24,7 @@
               "description": "supported versions",
               "type": "string",
               "listEnum": [
-                "inseefrlab/onyxia-vscode-pyspark:py3.12.4-spark3.5.2",
+                "inseefrlab/onyxia-vscode-pyspark:py3.12.5-spark3.5.2",
                 "inseefrlab/onyxia-vscode-pyspark:py3.11.9-spark3.5.2"
               ],
               "render": "list",
@@ -32,7 +32,7 @@
                 "value": true,
                 "path": "service/image/custom/enabled"
               },
-              "default": "inseefrlab/onyxia-vscode-pyspark:py3.12.4-spark3.5.2"
+              "default": "inseefrlab/onyxia-vscode-pyspark:py3.12.5-spark3.5.2"
             },
             "custom": {
               "description": "use a custom vscode docker image",
@@ -50,7 +50,7 @@
                 "version": {
                   "description": "vscode unsupported version",
                   "type": "string",
-                  "default": "inseefrlab/onyxia-vscode-pyspark:py3.12.4-spark3.5.2",
+                  "default": "inseefrlab/onyxia-vscode-pyspark:py3.12.5-spark3.5.2",
                   "hidden": {
                     "value": false,
                     "path": "service/image/custom/enabled"

--- a/charts/vscode-pyspark/values.yaml
+++ b/charts/vscode-pyspark/values.yaml
@@ -4,11 +4,11 @@ global:
 
 service:
   image:
-    version: "inseefrlab/onyxia-vscode-pyspark:py3.12.4-spark3.5.2"
+    version: "inseefrlab/onyxia-vscode-pyspark:py3.12.5-spark3.5.2"
     pullPolicy: IfNotPresent
     custom:
       enabled: false
-      version: "inseefrlab/onyxia-vscode-pyspark:py3.12.4-spark3.5.2"
+      version: "inseefrlab/onyxia-vscode-pyspark:py3.12.5-spark3.5.2"
 
 spark:
   sparkui: false

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.6
+version: 2.0.7
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -23,9 +23,9 @@
             "version": {
               "description": "vscode supported version",
               "type": "string",
-              "default": "inseefrlab/onyxia-vscode-python:py3.12.4",
+              "default": "inseefrlab/onyxia-vscode-python:py3.12.5",
               "listEnum": [
-                "inseefrlab/onyxia-vscode-python:py3.12.4",
+                "inseefrlab/onyxia-vscode-python:py3.12.5",
                 "inseefrlab/onyxia-vscode-python:py3.11.9"
               ],
               "render": "list",
@@ -50,7 +50,7 @@
                 "version": {
                   "description": "vscode unsupported version",
                   "type": "string",
-                  "default": "inseefrlab/onyxia-vscode-python:py3.12.4",
+                  "default": "inseefrlab/onyxia-vscode-python:py3.12.5",
                   "hidden": {
                     "value": false,
                     "path": "service/image/custom/enabled"

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -4,11 +4,11 @@ global:
 
 service:
   image:
-    version: "inseefrlab/onyxia-vscode-python:py3.12.4"
+    version: "inseefrlab/onyxia-vscode-python:py3.12.5"
     pullPolicy: IfNotPresent
     custom:
       enabled: false
-      version: "inseefrlab/onyxia-vscode-python:py3.12.4"
+      version: "inseefrlab/onyxia-vscode-python:py3.12.5"
 
 security:
   password: "changeme"


### PR DESCRIPTION
### Description of the change
All Python-based charts now use the new Python 3.12.5 images (soon to be published).

### Checklist
- [x] Chart version bumped in `Chart.yaml`
- [x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
