### PR TITLE
[library-chart] Partial rollback of Spark proxy exceptions

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.5.25
+version: 1.5.26
 type: library

--- a/charts/library-chart/templates/_secret.tpl
+++ b/charts/library-chart/templates/_secret.tpl
@@ -395,12 +395,9 @@ Flag to disable certificate checking for Spark
 
 {{/* Build a spark (or java) oriented non proxy hosts list from the linux based noProxy variable */}}
 {{- if (.Values.proxy).enabled -}}
-{{- if .Values.proxy.httpProxy }}
-{{- printf " -Dhttp.nonProxyHosts=%v" .Values.proxy.httpProxy }}
-{{- end }}
-{{- if .Values.proxy.httpsProxy }}
-{{- printf " -Dhttps.nonProxyHosts=%v" .Values.proxy.httpsProxy }}
-{{- end }}
+{{- $nonProxyHosts := regexReplaceAllLiteral "\\|\\." (regexReplaceAllLiteral "^(\\.)" (replace "," "|" (default "localhost" .Values.proxy.noProxy))  "*.") "|*." -}}
+{{- printf " -Dhttp.nonProxyHosts=%v" $nonProxyHosts }}
+{{- printf " -Dhttps.nonProxyHosts=%v" $nonProxyHosts }}
 {{- end -}}
 
 {{- end }}


### PR DESCRIPTION
<!--
 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Partial rollback of https://github.com/InseeFrLab/helm-charts-interactive-services/commit/54f219505ddd37717e35b988daea46f9195f9d54#diff-aa92606069b7c34b1dd15e3161a4fe088432100935d45c9677b64f5a38efd2daR397

While keeping the new test using `.Values.proxy.enabled` instead of `.Values.proxy`, add back the old $NO_PROXY based value for `-Dhttp.nonProxyHosts` and `-Dhttps.nonProxyHosts`

### Checklist

- [x] Chart version bumped in `Chart.yaml`
- [x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
