### PR TITLE
[spark based charts] Bump library-chart to fix nonProxyHosts config

### DIFF
--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.4
+version: 2.1.5
 
 dependencies:
   - name: library-chart
-    version: 1.5.25
+    version: 1.5.26
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,8 +23,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3
 dependencies:
   - name: library-chart
-    version: 1.5.25
+    version: 1.5.26
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.4
+version: 2.1.5
 
 dependencies:
   - name: library-chart
-    version: 1.5.25
+    version: 1.5.26
     repository: https://inseefrlab.github.io/helm-charts-interactive-services


### PR DESCRIPTION
<!--
 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Bump library-chart for Spark-based charts to fix nonProxyHosts config (see #162). Scope : 

- jupyter-pyspark
- rstudio-sparkr
- vscode-pyspark

### Checklist

- [x] Chart version bumped in `Chart.yaml`
- [x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
