### PR TITLE
[library-chart] modify condition on ingress tls secretName

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.5.26
+version: 1.5.27
 type: library

--- a/charts/library-chart/templates/_ingress.tpl
+++ b/charts/library-chart/templates/_ingress.tpl
@@ -57,7 +57,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
-    {{- if .Values.ingress.useCertManager }}
+    {{- if or .Values.ingress.useCertManager .Values.ingress.useTlsSecret}}
       secretName: tls-cert-{{ include "library-chart.fullname" . }}
     {{- end }}
 {{- end }}
@@ -97,7 +97,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.userHostname | quote }}
-    {{- if .Values.ingress.useCertManager }}
+    {{- if or .Values.ingress.useCertManager .Values.ingress.useTlsSecret}}
       secretName: tls-cert-{{ include "library-chart.fullname" . }}
     {{- end }}
 {{- end }}
@@ -138,7 +138,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.sparkHostname | quote }}
-    {{- if .Values.ingress.useCertManager }}
+    {{- if or .Values.ingress.useCertManager .Values.ingress.useTlsSecret }}
       secretName: tls-cert-{{ include "library-chart.fullname" . }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change
Add `useTlsSecret` variable to allow users to use the secretName in ingress tls without having to set "useCertManager" variable to true

### Checklist

- [ x] Chart version bumped in `Chart.yaml`
- [ x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
