### PR TITLE
[All] add default value ingress.usetlssecret

### DIFF
--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.5
+version: 2.1.6
 
 dependencies:
   - name: library-chart
-    version: 1.5.26
+    version: 1.5.27
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -691,6 +691,14 @@
             "hidden": true,
             "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
           }
+        },
+        "useTlsSecret":{
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
         }
       }
     },

--- a/charts/jupyter-pyspark/values.yaml
+++ b/charts/jupyter-pyspark/values.yaml
@@ -180,6 +180,7 @@ ingress:
   #      - chart-example.local
   useCertManager: false
   certManagerClusterIssuer: ""
+  useTlsSecret: false
 
 route:
   enabled: false

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.5
+version: 2.1.6
 
 dependencies:
   - name: library-chart
-    version: 1.5.26
+    version: 1.5.27
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -662,7 +662,15 @@
                         "hidden": true,
                         "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
                     }
-                }
+                },
+                "useTlsSecret":{
+                    "type": "boolean",
+                    "description": "Whether you want to use the specified secretName in ingress tls",
+                    "default": false,
+                    "x-onyxia": {
+                      "hidden": true
+                    }
+                }          
             }
         },
         "route": {

--- a/charts/jupyter-python/values.yaml
+++ b/charts/jupyter-python/values.yaml
@@ -149,6 +149,7 @@ ingress:
   #      - chart-example.local
   useCertManager: false
   certManagerClusterIssuer: ""
+  useTlsSecret: false
 
 route:
   enabled: false

--- a/charts/rstudio-sparkr/Chart.yaml
+++ b/charts/rstudio-sparkr/Chart.yaml
@@ -23,8 +23,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.3
+version: 2.1.4
 dependencies:
   - name: library-chart
-    version: 1.5.26
+    version: 1.5.27
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio-sparkr/values.schema.json
+++ b/charts/rstudio-sparkr/values.schema.json
@@ -637,7 +637,15 @@
                       "hidden": true,
                       "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
                     }
-                }
+                },
+                "useTlsSecret":{
+                    "type": "boolean",
+                    "description": "Whether you want to use the specified secretName in ingress tls",
+                    "default": false,
+                    "x-onyxia": {
+                      "hidden": true
+                    }
+                }          
             }
         },
         "route": {

--- a/charts/rstudio-sparkr/values.yaml
+++ b/charts/rstudio-sparkr/values.yaml
@@ -167,6 +167,7 @@ ingress:
   #      - chart-example.local
   useCertManager: false
   certManagerClusterIssuer: ""
+  useTlsSecret: false
 
 route:
   enabled: false

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3
 dependencies:
   - name: library-chart
-    version: 1.5.26
+    version: 1.5.27
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -611,7 +611,15 @@
                         "hidden": true,
                         "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
                     }
-                }
+                },
+                "useTlsSecret":{
+                    "type": "boolean",
+                    "description": "Whether you want to use the specified secretName in ingress tls",
+                    "default": false,
+                    "x-onyxia": {
+                      "hidden": true
+                    }
+                }          
             }
         },
         "route": {

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -125,6 +125,7 @@ ingress:
   #      - chart-example.local
   useCertManager: false
   certManagerClusterIssuer: ""
+  useTlsSecret: false
 
 route:
   enabled: false

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,9 +24,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.6
+version: 2.1.7
 
 dependencies:
   - name: library-chart
-    version: 1.5.26
+    version: 1.5.27
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/values.schema.json
+++ b/charts/vscode-pyspark/values.schema.json
@@ -674,6 +674,14 @@
             "hidden": true,
             "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
           }
+        },
+        "useTlsSecret":{
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
         }
       }
     },

--- a/charts/vscode-pyspark/values.yaml
+++ b/charts/vscode-pyspark/values.yaml
@@ -180,6 +180,7 @@ ingress:
   #      - chart-example.local
   useCertManager: false
   certManagerClusterIssuer: ""
+  useTlsSecret: false
 
 route:
   enabled: false

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.6
+version: 2.1.7
 
 dependencies:
   - name: library-chart
-    version: 1.5.26
+    version: 1.5.27
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -671,6 +671,14 @@
             "hidden": true,
             "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
           }
+        },
+        "useTlsSecret":{
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
         }
       }
     },

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -144,6 +144,7 @@ ingress:
   #      - chart-example.local
   useCertManager: false
   certManagerClusterIssuer: ""
+  useTlsSecret: false
 
 
 route:


### PR DESCRIPTION
### Description of the change
Add default value for ingress.useTlsSecret in all charts & upgrade to library-chart 1.5.27 due to #166 

### Checklist

- [x ] Chart version bumped in `Chart.yaml`
- [ x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
