### PR TITLE
[librairy Chart] Adding 2 new keys into S3 secret 

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.5.46
+version: 1.6.0
 type: library

--- a/charts/library-chart/templates/_secret.tpl
+++ b/charts/library-chart/templates/_secret.tpl
@@ -27,6 +27,8 @@ stringData:
   AWS_DEFAULT_REGION: {{ .Values.s3.defaultRegion | quote }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.s3.secretAccessKey | quote }}
   AWS_SESSION_TOKEN: {{ .Values.s3.sessionToken | quote }}
+  AWS_PATH_STYLE_ACCES: "{{ .Values.s3.pathStyleAcces }}"
+  AWS_WORKING_DIRECTORY_PATH: "{{ .Values.s3.workingDirectoryPath }}"
 {{- end }}
 {{- end }}
 

--- a/charts/library-chart/templates/_secret.tpl
+++ b/charts/library-chart/templates/_secret.tpl
@@ -27,7 +27,7 @@ stringData:
   AWS_DEFAULT_REGION: {{ .Values.s3.defaultRegion | quote }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.s3.secretAccessKey | quote }}
   AWS_SESSION_TOKEN: {{ .Values.s3.sessionToken | quote }}
-  AWS_PATH_STYLE_ACCES: "{{ .Values.s3.pathStyleAcces }}"
+  AWS_PATH_STYLE_ACCESS: "{{ .Values.s3.pathStyleAccess }}"
   AWS_WORKING_DIRECTORY_PATH: "{{ .Values.s3.workingDirectoryPath }}"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

 bump to 1.6.0 and Adding 2 new keys into S3 secret AWS_WORKING_DIRECTORY_PATH and  AWS_PATH_STYLE_ACCES
### Checklist

- [X ] Chart version bumped in `Chart.yaml`
- [X ] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
