### PR TITLE
[library-chart] Add support for Path type override

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 1.7.11
+version: 1.7.12
 type: library

--- a/charts/library-chart/templates/_ingress.tpl
+++ b/charts/library-chart/templates/_ingress.tpl
@@ -68,7 +68,7 @@ spec:
     - host: {{ .Values.ingress.hostname | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.path | default "/" }}
             pathType: Prefix
             backend:
               service:
@@ -128,7 +128,7 @@ spec:
     {{- end }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.userPath | default "/" }}
             pathType: Prefix
             backend:
               service:
@@ -174,7 +174,7 @@ spec:
     - host: {{ .Values.ingress.sparkHostname | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.sparkPath | default "/" }}
             pathType: Prefix
             backend:
               service:

--- a/charts/library-chart/templates/_route.tpl
+++ b/charts/library-chart/templates/_route.tpl
@@ -34,7 +34,7 @@ metadata:
     {{- include "library-chart.route.annotations" . | nindent 4 }}
 spec:
   host: {{ .Values.route.hostname | quote }}
-  path: /
+  path: {{ .Values.route.path | default "/" }}
   to:
     kind: Service
     name: {{ $fullName }}
@@ -83,7 +83,7 @@ spec:
 {{- else }}
   host: {{ regexReplaceAll "([^\\.]+)\\.(.*)" .Values.route.userHostname (printf "${1}-%d.${2}" (int $userPort)) | quote }}
 {{- end }}
-  path: /
+  path: {{ .Values.route.userPath | default "/" }}
   to:
     kind: Service
     name: {{ $fullName }}
@@ -130,7 +130,7 @@ metadata:
     {{- include "library-chart.route.annotations" . | nindent 4 }}
 spec:
   host: {{ .Values.route.sparkHostname | quote }}
-  path: /
+  path: {{ .Values.route.sparkPath | default "/" }}
   to:
     kind: Service
     name: {{ $fullName }}


### PR DESCRIPTION
<!--
 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change
Following https://github.com/InseeFrLab/onyxia/issues/996 in the aim of making Onyxia able -for some services- to handle path-type URL instead of sub-domain, we're trying to override dynamically inject the path in the ide/ingress.json (https://github.com/InseeFrLab/onyxia-api/blob/b47eece8103fa6bc78302390b3f0b8570de9e494/onyxia-api/src/main/resources/schemas/ide/ingress.json#L31).
However since the variable does not exists in your charts i believe it will not work prior to this change.

### Checklist

- [X] Chart version bumped in `Chart.yaml`
- [X] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
