### PR TITLE
[jupyter-pyspark] Integrating Trevas

### DIFF
--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.15
+version: 2.4.0
 dependencies:
   - name: library-chart
     version: 1.7.12

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -25,7 +25,8 @@
               "type": "string",
               "listEnum": [
                 "inseefrlab/onyxia-jupyter-pyspark:py3.13.5-spark3.5.5",
-                "inseefrlab/onyxia-jupyter-pyspark:py3.12.11-spark3.5.5"
+                "inseefrlab/onyxia-jupyter-pyspark:py3.12.11-spark3.5.5",
+                "inseefrlab/trevas-jupyter:0.8.0"
               ],
               "render": "list",
               "hidden": {
@@ -831,7 +832,7 @@
             "hidden": true
           }
         },
-        "tlsSecretName":{
+        "tlsSecretName": {
           "type": "string",
           "default": "",
           "x-onyxia": {


### PR DESCRIPTION
### Description of the change

We are integrating back Trevas to the PySpark version of the Jupyter service.

### Checklist

- [x] Chart version bumped in `Chart.yaml`
- [x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
