### PR TITLE
[Rstudio] Update statefulset.yaml env uv

### DIFF
--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.11
+version: 2.3.12
 dependencies:
   - name: library-chart
     version: 1.7.12

--- a/charts/rstudio/templates/statefulset.yaml
+++ b/charts/rstudio/templates/statefulset.yaml
@@ -153,6 +153,8 @@ spec:
             - name: DARK_MODE
               value: "true"
             {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
           envFrom:
             {{- if (.Values.git).enabled }}
             - secretRef:


### PR DESCRIPTION
adding uv to rstudio 
for service rstudio-r-julia-python

<!--
 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change
  Adding UV_CACHE_DIR
              value: /home/{{ .Values.environment.user }}/work/.cache/uv
 to env variable like vscode template
https://github.com/InseeFrLab/helm-charts-interactive-services/blob/main/charts/vscode-python/templates/statefulset.yaml#L202-L203
i put it on the highest level and not direcly in the rstudio-r-python-julia because or Romain's adivce 

### Checklist

- [x ] Chart version bumped in `Chart.yaml`
- [ x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
