### PR TITLE
Marimo: new Charts

### DIFF
--- a/charts/marimo-pyspark/.helmignore
+++ b/charts/marimo-pyspark/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/marimo-pyspark/Chart.yaml
+++ b/charts/marimo-pyspark/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: marimo-pyspark
+description: Marimo reactive Python notebook with PySpark support.
+icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/marimo.png
+keywords:
+  - Marimo
+  - Python
+  - Spark
+  - VTL
+home: https://marimo.io/
+sources:
+  - https://github.com/InseeFrLab/images-datascience
+  - https://github.com/InseeFrLab/helm-charts-interactive-services
+type: application
+version: 0.0.1
+dependencies:
+  - name: library-chart
+    version: 2.0.4
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/marimo-pyspark/templates/NOTES.txt
+++ b/charts/marimo-pyspark/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python + Spark)" "context" $) -}}

--- a/charts/marimo-pyspark/templates/NOTES.txt
+++ b/charts/marimo-pyspark/templates/NOTES.txt
@@ -1,1 +1,1 @@
-{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python + Spark)" "context" $) -}}
+{{- template "library-chart.notes" (dict "serviceName" "Marimo (Python + Spark)" "context" $) -}}

--- a/charts/marimo-pyspark/templates/configmap-repository.yaml
+++ b/charts/marimo-pyspark/templates/configmap-repository.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapRepository" . }}

--- a/charts/marimo-pyspark/templates/ingress-sparkui.yaml
+++ b/charts/marimo-pyspark/templates/ingress-sparkui.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressSpark" . }}

--- a/charts/marimo-pyspark/templates/ingress-user.yaml
+++ b/charts/marimo-pyspark/templates/ingress-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressUser" . }}

--- a/charts/marimo-pyspark/templates/ingress.yaml
+++ b/charts/marimo-pyspark/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingress" . }}

--- a/charts/marimo-pyspark/templates/networkpolicy-ingress.yaml
+++ b/charts/marimo-pyspark/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicyIngress" . }}

--- a/charts/marimo-pyspark/templates/networkpolicy.yaml
+++ b/charts/marimo-pyspark/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/marimo-pyspark/templates/pvc.yaml
+++ b/charts/marimo-pyspark/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/marimo-pyspark/templates/role-binding-scc.yaml
+++ b/charts/marimo-pyspark/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/marimo-pyspark/templates/role-binding.yaml
+++ b/charts/marimo-pyspark/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/marimo-pyspark/templates/route-sparkui.yaml
+++ b/charts/marimo-pyspark/templates/route-sparkui.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeSpark" . }}

--- a/charts/marimo-pyspark/templates/route-user.yaml
+++ b/charts/marimo-pyspark/templates/route-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeUser" . }}

--- a/charts/marimo-pyspark/templates/route.yaml
+++ b/charts/marimo-pyspark/templates/route.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.route" . }}

--- a/charts/marimo-pyspark/templates/secret-assistant.yaml
+++ b/charts/marimo-pyspark/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistant" . }}

--- a/charts/marimo-pyspark/templates/secret-cacerts.yaml
+++ b/charts/marimo-pyspark/templates/secret-cacerts.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCacerts" . }}

--- a/charts/marimo-pyspark/templates/secret-chromadb.yaml
+++ b/charts/marimo-pyspark/templates/secret-chromadb.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretChromaDB" . }}

--- a/charts/marimo-pyspark/templates/secret-coresite.yaml
+++ b/charts/marimo-pyspark/templates/secret-coresite.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCoreSite" . }}

--- a/charts/marimo-pyspark/templates/secret-extraenv.yaml
+++ b/charts/marimo-pyspark/templates/secret-extraenv.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretExtraEnv" . }}

--- a/charts/marimo-pyspark/templates/secret-git.yaml
+++ b/charts/marimo-pyspark/templates/secret-git.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretGit" . }}

--- a/charts/marimo-pyspark/templates/secret-hive.yaml
+++ b/charts/marimo-pyspark/templates/secret-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretHive" . }}

--- a/charts/marimo-pyspark/templates/secret-ivysettings.yaml
+++ b/charts/marimo-pyspark/templates/secret-ivysettings.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretIvySettings" . }}

--- a/charts/marimo-pyspark/templates/secret-metaflow.yaml
+++ b/charts/marimo-pyspark/templates/secret-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMetaflow" . }}

--- a/charts/marimo-pyspark/templates/secret-milvus.yaml
+++ b/charts/marimo-pyspark/templates/secret-milvus.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMilvus" . }}

--- a/charts/marimo-pyspark/templates/secret-mlflow.yaml
+++ b/charts/marimo-pyspark/templates/secret-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMLFlow" . }}

--- a/charts/marimo-pyspark/templates/secret-postgresql.yaml
+++ b/charts/marimo-pyspark/templates/secret-postgresql.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretPostgreSQL" . }}

--- a/charts/marimo-pyspark/templates/secret-proxy.yaml
+++ b/charts/marimo-pyspark/templates/secret-proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretProxy" . }}

--- a/charts/marimo-pyspark/templates/secret-s3.yaml
+++ b/charts/marimo-pyspark/templates/secret-s3.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretS3" . }}

--- a/charts/marimo-pyspark/templates/secret-sparkconf.yaml
+++ b/charts/marimo-pyspark/templates/secret-sparkconf.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretSparkConf" . }}

--- a/charts/marimo-pyspark/templates/secret-token.yaml
+++ b/charts/marimo-pyspark/templates/secret-token.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretToken" . }}

--- a/charts/marimo-pyspark/templates/secret-vault.yaml
+++ b/charts/marimo-pyspark/templates/secret-vault.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretVault" . }}

--- a/charts/marimo-pyspark/templates/service.yaml
+++ b/charts/marimo-pyspark/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/marimo-pyspark/templates/serviceaccount.yaml
+++ b/charts/marimo-pyspark/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/marimo-pyspark/templates/statefulset.yaml
+++ b/charts/marimo-pyspark/templates/statefulset.yaml
@@ -1,0 +1,389 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  {{- if .Values.global.suspend }}
+  replicas: 0
+  {{- else }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (.Values.git).enabled }}
+        checksum/git: {{ include (print $.Template.BasePath "/secret-git.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.s3).enabled }}
+        checksum/s3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.vault).enabled }}
+        checksum/vault: {{ include (print $.Template.BasePath "/secret-vault.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretCoreSite" .))) }}
+        checksum/coresite: {{ include (print $.Template.BasePath "/secret-coresite.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretHive" .))) }}
+        checksum/hive: {{ include (print $.Template.BasePath "/secret-hive.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretIvySettings" .))) }}
+        checksum/ivysettings: {{ include (print $.Template.BasePath "/secret-ivysettings.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMetaflow" .))) }}
+        checksum/metaflow: {{ include (print $.Template.BasePath "/secret-metaflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/secret-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+        checksum/chromadb: {{ include (print $.Template.BasePath "/secret-chromadb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+        checksum/milvus: {{ include (print $.Template.BasePath "/secret-milvus.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+        checksum/postgresql: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "library-chart.repository.enabled"  .) }}
+        checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretSparkConf" .))) }}
+        checksum/sparkconf: {{ include (print $.Template.BasePath "/secret-sparkconf.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.certificates).cacerts }}
+        checksum/cacerts: {{ .Values.certificates.cacerts | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.runtimeClassName -}}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
+      volumes:
+        - name: home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        {{- if (.Values.proxy).enabled }}
+        - name: secret-proxy
+          secret:
+            secretName: {{ include "library-chart.secretNameProxy" . }}
+        {{- end }}
+        {{- if .Values.spark.default }}
+        - name: secret-sparkconf
+          secret:
+            secretName: {{ include "library-chart.secretNameSparkConf" . }}
+        {{- end }}
+        {{- if and (.Values.spark).default (.Values.repository).mavenRepository }}
+        - name: secret-ivysettings
+          secret:
+            secretName: {{ include "library-chart.secretNameIvySettings" . }}
+        {{- end }}
+        {{- if (.Values.discovery).hive }}
+        - name: secret-hive
+          secret:
+            secretName: {{ include "library-chart.secretNameHive" . }}
+        {{- end }}
+        {{- if (.Values.discovery).metaflow }}
+        - name: secret-metaflow
+          secret:
+            secretName: {{ include "library-chart.secretNameMetaflow" . }}
+        {{- end }}
+        - name: config-files
+          emptyDir: {}
+        {{- if .Values.s3.enabled }}
+        - name: secret-coresite
+          secret:
+            secretName: {{ include "library-chart.secretNameCoreSite" . }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        - name: cacerts
+          secret:
+            secretName: {{ include "library-chart.secretNameCacerts" . }}
+        {{- end }}
+        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistant" . }}
+        {{- end }}
+        - name: token
+          secret:
+            secretName: {{ include "library-chart.secretNameToken" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: make-secrets-writable
+          image: {{ .Values.service.initContainer.image }}
+          imagePullPolicy: {{ .Values.service.initContainer.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              echo 'initContainer make-secrets-writable is started';
+              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              mkdir /dest/continue
+              cp /src/continue/config.yaml /dest/continue/config.yaml
+              {{- end }}
+              {{- if .Values.s3.enabled }}
+              mkdir /dest/coresite;
+              cp /src/coresite/core-site.xml /dest/coresite/core-site.xml;
+              {{- end }}
+              {{- if .Values.spark.default }}
+              mkdir /dest/spark;
+              cp /src/spark/spark-defaults.conf /dest/spark/spark-defaults.conf;
+              {{- end }}
+              {{- if and (.Values.spark.default) (.Values.repository.mavenRepository) }}
+              mkdir /dest/ivysettings;
+              cp /src/ivysettings/ivysettings.xml /dest/ivysettings/ivysettings.xml;
+              {{- end }}
+              {{- if .Values.discovery.hive }}
+              mkdir /dest/hive;
+              cp /src/hive/hive-site.xml /dest/hive/hive-site.xml;
+              {{- end }}
+              {{- if .Values.discovery.metaflow }}
+              mkdir /dest/metaflow;
+              cp /src/metaflow/config.json /dest/metaflow/config.json;
+              {{- end }}
+              {{- if and .Values.certificates .Values.certificates.cacerts }}
+              mkdir /dest/cacerts;
+              {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
+              curl -s $(cat /cacerts/ca-certs.url) -o /tmp/ca.pem
+              {{- else }}
+              cp /cacerts/ca.pem /tmp/ca.pem
+              {{- end }}
+              awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
+              {{- end }}
+          volumeMounts:
+            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            - name: secret-assistant
+              mountPath: /src/continue
+            {{- end }}
+            - name: config-files
+              mountPath: /dest
+            {{- if (.Values.certificates).cacerts }}
+            - name: cacerts
+              mountPath: /cacerts
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - name: secret-coresite
+              mountPath: /src/coresite
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: secret-hive
+              mountPath: /src/hive
+            {{- end }}
+            {{- if and (.Values.spark.default) (.Values.repository.mavenRepository) }}
+            - name: secret-ivysettings
+              mountPath: /src/ivysettings
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name : secret-metaflow
+              mountPath: /src/metaflow
+            {{- end }}
+            {{- if (.Values.spark).default }}
+            - name: secret-sparkconf
+              mountPath: /src/spark
+            {{- end }}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.service.image.custom.enabled }}
+          image: "{{ .Values.service.image.custom.version }}"
+          {{- else }}
+          image: "{{ .Values.service.image.version }}"
+          {{- end }}
+          command: ["/bin/sh","-c"]
+          {{- if .Values.git.asCodeServerRoot }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
+          {{- else }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
+          {{- end }}
+          imagePullPolicy: {{ .Values.service.image.pullPolicy }}
+          env:
+            - name: KUBERNETES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: IMAGE_NAME
+              {{- if .Values.service.image.custom.enabled }}
+              value: "{{ .Values.service.image.custom.version }}"
+              {{- else }}
+              value: "{{ .Values.service.image.version }}"
+              {{- end }}
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: ROOT_PROJECT_DIRECTORY
+              value: /home/{{ .Values.environment.user }}/work
+            {{- if .Values.init.regionInit }}
+            - name: REGION_INIT_SCRIPT
+              value: {{ .Values.init.regionInit }}
+            {{- end }}
+            {{- if .Values.init.personalInit }}
+            - name: PERSONAL_INIT_SCRIPT
+              value: {{ .Values.init.personalInit }}
+            {{- end }}
+            {{- if .Values.init.personalInitArgs }}
+            - name: PERSONAL_INIT_ARGS
+              value: {{ .Values.init.personalInitArgs }}
+            {{- end }}
+            {{- if .Values.environment.root }}
+            - name: GRANT_SUDO
+              value: "yes"
+            {{- end }}
+            {{- if .Values.userPreferences.darkMode }}
+            - name: DARK_MODE
+              value: "true"
+            {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
+          envFrom:
+            - secretRef:
+                name: {{ include "library-chart.secretNameToken" . }}
+            {{- if (.Values.git).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameGit" . }}
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameS3" . }}
+            {{- end }}
+            {{- if (.Values.vault).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameVault" . }}
+            {{- end }}
+            {{- if (.Values.proxy).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameProxy" . }}
+            {{- end }}
+            {{- if (include "library-chart.repository.enabled"  .) }}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameRepository" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMLFlow" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNamePostgreSQL" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameChromaDB" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMilvus" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameExtraEnv" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 2
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          {{- if hasKey .Values "startupProbe" }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+            - name: token
+              mountPath: /home/{{ .Values.environment.user }}/.token
+              readOnly: true
+            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.continue
+              subPath: continue
+              name: config-files
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - mountPath: /usr/local/lib/hadoop/etc/hadoop/core-site.xml
+              subPath: coresite/core-site.xml
+              name: config-files
+            {{- end }}
+            {{- if (.Values.spark).default }}
+            - name: config-files
+              mountPath: /usr/local/lib/spark/conf/spark-defaults.conf
+              subPath: spark/spark-defaults.conf
+            {{- end }}
+            {{- if and (.Values.spark.default) (.Values.repository.mavenRepository) }}
+            - name: config-files
+              mountPath: /usr/local/lib/spark/conf/ivysettings.xml
+              subPath: ivysettings/ivysettings.xml
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: config-files
+              mountPath: /usr/local/lib/hive/conf/hive-site.xml
+              subPath: hive/hive-site.xml
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.metaflowconfig
+              subPath: metaflow
+            {{- end }}
+            {{- if (.Values.certificates).pathToCaBundle }}
+            - name: config-files
+              mountPath: {{ .Values.certificates.pathToCaBundle }}
+              subPath: cacerts
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/marimo-pyspark/templates/tests/test-connection.yaml
+++ b/charts/marimo-pyspark/templates/tests/test-connection.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.testConnection" . }}

--- a/charts/marimo-pyspark/values.schema.json
+++ b/charts/marimo-pyspark/values.schema.json
@@ -1,0 +1,1165 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "service": {
+      "title": "Service",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Docker image",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "title": "Pull image from registry",
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "title": "Name of the service's Docker image",
+              "type": "string",
+              "listEnum": [
+                "pacordonnier/marimo-pyspark:py3.13.12-spark4.1.1",
+                "pacordonnier/marimo-pyspark:py3.12.13-spark4.1.1",
+                "pacordonnier/marimo-pyspark:py3.13.8-spark3.5.7",
+                "pacordonnier/marimo-pyspark:py3.12.13-spark3.5.7"
+              ],
+              "render": "list",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              },
+              "default": "pacordonnier/marimo-pyspark:py3.13.12-spark4.1.1"
+            },
+            "custom": {
+              "title": "Custom image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Use a custom image instead",
+                  "type": "boolean",
+                  "default": false,
+                  "x-onyxia": {
+                    "overwriteSchemaWith": "ide/customImage.json"
+                  }
+                },
+                "version": {
+                  "title": "Name of the custom image",
+                  "type": "string",
+                  "default": "pacordonnier/marimo-pyspark:py3.13.12-spark4.1.1",
+                  "hidden": {
+                    "value": false,
+                    "path": "enabled",
+                    "isPathRelative": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "spark": {
+      "title": "Spark",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "spark.json"
+      },
+      "properties": {
+        "ui": {
+          "title": "Enable monitoring interface",
+          "type": "boolean",
+          "default": true
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-spark.{{k8s.domain}}"
+          }
+        },
+        "default": {
+          "title": "Create a Spark configuration",
+          "type": "boolean",
+          "default": true
+        },
+        "disabledCertChecking": {
+          "title": "Disable certificate checking for S3 storage",
+          "description": "(do not disable in production)",
+          "type": "boolean",
+          "default": false
+        },
+        "userConfig": {
+          "title": "Spark configuration (spark-default.conf)",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "spark.dynamicAllocation.enabled": "true",
+            "spark.dynamicAllocation.initialExecutors": "1",
+            "spark.dynamicAllocation.minExecutors": "1",
+            "spark.dynamicAllocation.maxExecutors": "10",
+            "spark.executor.memory": "2g",
+            "spark.driver.memory": "2g",
+            "spark.dynamicAllocation.executorAllocationRatio": "1",
+            "spark.dynamicAllocation.shuffleTracking.enabled": "true",
+            "spark.hadoop.fs.s3a.bucket.all.committer.magic.enabled": "true"
+          },
+          "hidden": {
+            "value": false,
+            "path": "spark/default"
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources (CPU/RAM)",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/resources.json"
+      },
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Guaranteed CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu"
+            },
+            "memory": {
+              "description": "Guaranteed memory allocation",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory"
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Maximum CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu"
+            },
+            "memory": {
+              "description": "Maximum memory allocation",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory"
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/persistence.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Create a persistent volume",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "title": "Persistent volume size",
+          "type": "string",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "overwriteDefaultWith": "region.resources.disk",
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "init": {
+      "title": "Initialization scripts",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/init.json"
+      },
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "personalInit": {
+          "title": "Use a custom script (URL)",
+          "type": "string",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "title": "Arguments for the custom script",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "extraEnvVars": {
+      "title": "Environment variables available within your service",
+      "type": "array",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/extraenv.json"
+      },
+      "items": {
+        "title": "",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "VAR_NAME",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "title": "Kubernetes permissions",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "role-spark.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Kubernetes access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "role": {
+          "title": "Kubernetes role",
+          "description": "access is restricted to your own namespace",
+          "type": "string",
+          "default": "admin",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "listEnum": [
+            "view",
+            "edit",
+            "admin"
+          ],
+          "render": "list"
+        }
+      }
+    },
+    "vault": {
+      "title": "Vault access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/vault.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Vault access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "token": {
+          "title": "Vault token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "url": {
+          "title": "Vault server URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "mount": {
+          "title": "Secret engine",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "directory": {
+          "title": "Top-level directory",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secret": {
+          "title": "Path to the secret to load",
+          "description": "The secret will be converted into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "s3": {
+      "title": "S3 object storage",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/s3.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable S3 access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "accessKeyId": {
+          "title": "Access Key ID",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_ACCESS_KEY_ID}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "endpoint": {
+          "title": "S3 endpoint URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "defaultRegion": {
+          "title": "Default region",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secretAccessKey": {
+          "title": "Secret Access Key",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "sessionToken": {
+          "title": "Session token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "pathStyleAccess": {
+          "title": "Path-style access",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.pathStyleAccess}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "workingDirectoryPath": {
+          "title": "Working directory path",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.workingDirectoryPath}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "git": {
+      "title": "Git access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/git.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable git access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "title": "User name",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "email": {
+          "title": "User email",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "cache": {
+          "title": "Credentials caching duration",
+          "description": "(in seconds)",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "token": {
+          "title": "Personal Access Token",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "repository": {
+          "title": "Project repository",
+          "description": "cloned in service",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "branch": {
+          "title": "Specific branch to use",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "asCodeServerRoot": {
+          "title": "Open the service in the clone folder",
+          "type": "boolean",
+          "default": false,
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "networking": {
+      "title": "Network access",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/networking.json"
+      },
+      "properties": {
+        "user": {
+          "title": "Ports",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable access to your service through specific ports",
+              "type": "boolean",
+              "default": false
+            },
+            "port": {
+              "title": "Port number to expose",
+              "type": "integer",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            },
+            "ports": {
+              "title": "Port numbers to expose",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "uniqueItems": true,
+                "default": 5000
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "title": "Third party services discovery",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "title": "Discover Hive Metastore services",
+          "type": "boolean",
+          "default": true
+        },
+        "mlflow": {
+          "title": "Discover MLflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "metaflow": {
+          "title": "Discover Metaflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "chromadb": {
+          "title": "Discover ChromaDB services",
+          "type": "boolean",
+          "default": true
+        },
+        "milvus": {
+          "title": "Discover Milvus services",
+          "type": "boolean",
+          "default": true
+        },
+        "postgresql": {
+          "title": "Discover PostgreSQL services",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "security": {
+      "title": "Security",
+      "type": "object",
+      "properties": {
+        "password": {
+          "title": "Service password",
+          "type": "string",
+          "default": "changeme",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{service.oneTimePassword}}",
+            "overwriteSchemaWith": "ide/password.json"
+          }
+        },
+        "networkPolicy": {
+          "title": "Network access policy",
+          "type": "object",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "title": "Only allow access from the same namespace",
+              "type": "boolean",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "description": "Array of sources allowed to have network access to your service",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "title": "Node selector",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.nodeSelector"
+      }
+    },
+    "openshiftSCC": {
+      "description": "configuration for openshift compatibility",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/openshiftSCC.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "enable rolebinding with openshift scc",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.enabled"
+          }
+        },
+        "scc": {
+          "type": "string",
+          "description": "name of scc for rolebinding",
+          "default": "anyuid",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.scc"
+          }
+        }
+      }
+    },
+    "ingress": {
+      "title": "Ingress Details",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/ingress.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        },
+        "useCertManager": {
+          "type": "boolean",
+          "description": "Whether CertManager should be used to generate a certificate",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.useCertManager"
+          }
+        },
+        "certManagerClusterIssuer": {
+          "type": "string",
+          "description": "certManager cluster issuer",
+          "title": "CertManager Cluster Issuer",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
+          }
+        },
+        "useTlsSecret": {
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tlsSecretName":{
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "repository.json"
+      },
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
+    },
+    "proxy": {
+      "description": "It can be used to inject proxy settings in the services",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "proxy.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Inject proxy settings",
+          "default": false
+        },
+        "httpProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTP.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTPS.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "enterprise local domain that should not take proxy comma separated",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        }
+      }
+    },
+    "startupProbe": {
+      "description": "Startup probe",
+      "type": "object",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "default": 60
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "default": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "default": 2
+        }
+      },
+      "default": {
+        "failureThreshold": 60,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "timeoutSeconds": 2
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.startupProbe",
+        "overwriteSchemaWith": "ide/startupProbe.json"
+      }
+    },
+    "tolerations": {
+      "description": "Array of tolerations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "userPreferences": {
+      "title": "User Preferences",
+      "type": "object",
+      "properties": {
+        "darkMode": {
+          "type": "boolean",
+          "description": "dark mode is or is not enabled",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.darkMode"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Preferred language",
+          "default": "en",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.lang"
+          }
+        },
+        "aiAssistant":{
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Continue, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default":"",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase":{
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey":{
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            },
+            "useLegacyCompletionsEndpoint":{
+              "title": "use legacy completions endpoint",
+              "type": "boolean",
+              "default": true,
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
+              }
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "certificates": {
+      "description": "It can be used to inject certificate authority into the services, if the Helm chart in the catalog allows it you can bind this value to the Helm chart value to add some certificate authorities in the pod.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "certificates.json"
+      },
+      "default": {},
+      "properties": {
+        "cacerts": {
+          "type": "string",
+          "description": "String of concatenated CA certificates. Alternatively a target URL can be provided.",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "pathToCaBundle": {
+          "type": "string",
+          "description": "String path where a bundle is made or injected by third party solution",
+          "default": "/usr/local/share/ca-certificates/",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "Warning message",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/message.json"
+      },
+      "properties": {
+        "fr": {
+          "type": "string",
+          "description": "message à ajouter dans les notes",
+          "default": ""
+        },
+        "en": {
+          "type": "string",
+          "description": "message to add in notes",
+          "default": ""
+        }
+      }
+    },
+    "runtimeClassName" : {
+      "type": "string",
+      "description": "Runtime Class Name",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/runtimeClassName.json"
+      }
+    }
+  }
+}

--- a/charts/marimo-pyspark/values.yaml
+++ b/charts/marimo-pyspark/values.yaml
@@ -1,0 +1,298 @@
+# Default values for vscode.
+global:
+  suspend: false
+
+service:
+  initContainer:
+    image: "inseefrlab/onyxia-base:latest"
+    pullPolicy: IfNotPresent
+  image:
+    version: "pacordonnier/marimo-pyspark:py3.13.12-spark4.1.1"
+    pullPolicy: IfNotPresent
+    custom:
+      enabled: false
+      version: "pacordonnier/marimo-pyspark:py3.13.12-spark4.1.1"
+
+spark:
+  ui: false
+  hostname: chart-example-spark.local
+  path: /
+  secretName: ""
+  default: true
+  disabledCertChecking: false
+  config:
+    spark.master: k8s://https://kubernetes.default.svc:443
+    spark.kubernetes.authenticate.driver.serviceAccountName: '{{ include "library-chart.fullname" . }}'
+    spark.kubernetes.driver.pod.name: '{{ include "library-chart.fullname" . }}-0'
+    spark.kubernetes.namespace: '{{ .Release.Namespace }}'
+    spark.kubernetes.container.image: '{{ ternary .Values.service.image.custom.version .Values.service.image.version .Values.service.image.custom.enabled }}'
+    spark.driver.extraJavaOptions: '{{ include "library-chart.sparkExtraJavaOptions" . }}'
+    spark.executor.extraJavaOptions: '{{ include "library-chart.sparkExtraJavaOptions" . }}'
+  userConfig:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.initialExecutors: "1"
+    spark.dynamicAllocation.minExecutors: "1"
+    spark.dynamicAllocation.maxExecutors: "10"
+    spark.executor.memory: "2g"
+    spark.driver.memory: "2g"
+    spark.dynamicAllocation.executorAllocationRatio: "1"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.hadoop.fs.s3a.bucket.all.committer.magic.enabled: "true"
+
+security:
+  password: "changeme"
+  networkPolicy:
+    enabled: false
+    from: []
+  allowlist:
+    enabled: false
+    ip: "0.0.0.0/0"
+
+init:
+  standardInitPath: "/opt/onyxia-init.sh"
+  regionInit: ""
+  personalInit: ""
+  personalInitArgs: ""
+
+# Array with (templated) extra environment variables to be made accessible within the service
+# e.g:
+# extraEnvVars:
+#   - name: FOO
+#     value: "bar"
+extraEnvVars: []
+
+environment:
+  user: onyxia
+  group: users
+
+s3:
+  # Specifies whether S3 credentials should be made available
+  enabled: false
+  # The name of the secret storing the S3 credentials
+  secretName: ""  # Generated based on the service's name if empty or not set
+  accessKeyId: ""
+  endpoint: ""
+  defaultRegion: ""
+  secretAccessKey: ""
+  sessionToken: ""
+  pathStyleAccess: false
+  workingDirectoryPath: ""
+
+vault:
+  # Specifies whether Vault credentials should be made available
+  enabled: false
+  # The name of the secret storing the Vault credentials
+  secretName: ""  # Generated based on the service's name if empty or not set
+  token: ""
+  url: ""
+  mount: ""
+  secret: ""
+  directory: ""
+
+git:
+  # Specifies whether git credentials should be made available
+  enabled: false
+  # The name of the secret storing the git credentials
+  secretName: ""  # Generated based on the service's name if empty or not set
+  name: ""
+  email: ""
+  cache: ""
+  token: ""
+  repository: ""
+  branch: ""
+  asCodeServerRoot: false
+
+proxy:
+  enabled: false
+  noProxy: ""
+  httpProxy: ""
+  httpsProxy: ""
+
+repository:
+  configMapName: ""
+  pipRepository: ""
+  condaRepository: ""
+  mavenRepository: ""
+
+# active ou non la recherche de secrets discovery dans le namespace
+# see secret-{service}.yaml
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+  chromadb: true
+  milvus: true
+  postgresql: true
+
+hive:
+  secretName: ""
+
+mlflow:
+  secretName: ""
+
+metaflow:
+  secretName: ""
+
+chromadb:
+  secretName: ""
+
+milvus:
+  secretName: ""
+
+postgresql:
+  secretName: ""
+
+coresite:
+  secretName: ""
+
+replicaCount: 1
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+kubernetes:
+  enabled: false
+  role: "view"
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 100
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    port: 2718
+  sparkui:
+    port: 4040
+  # Custom user-specified extra ports exposition.
+  # If ingress or route is enabled, the exposed ports are also made available at the
+  # {ingress,route}.userHostname URL (or variations, in case several ports are provided).
+  # Note: a non-empty networking.user.ports overrides networking.user.port
+  user:
+    enabled: false
+    port: 5000
+    ports: []
+
+ingress:
+  enabled: false
+  tls: true
+  ingressClassName: ""
+  annotations: []
+    # kubernetes.io/tls-acme: "true"
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  path: /
+  userPath: /
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+  useCertManager: false
+  certManagerClusterIssuer: ""
+  useTlsSecret: false
+  tlsSecretName: ""
+
+route:
+  enabled: false
+  annotations: []
+    # route.openshift.io/termination: "reencrypt"
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  tls:
+    termination: edge
+    # key:
+    # certificate:
+    # caCertificate:
+    # destinationCACertificate:
+  wildcardPolicy: None
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+persistence:
+  enabled: true
+  ## database data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 10Gi
+  # existingClaim: ""
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+
+userPreferences:
+  darkMode: false
+  language: "en"
+  aiAssistant:
+    enabled: false
+    model: ""
+    provider: ""
+    apiBase: ""
+    apiKey: ""
+    secretName: ""  # Generated based on the service's name if empty or not set
+    useLegacyCompletionsEndpoint: false
+
+openshiftSCC:
+  enabled: false
+  scc: ""
+
+certificates: {}
+  # pathToCaBundle: /usr/local/share/ca-certificates/
+  # cacerts: ""
+
+message:
+  fr: ""
+  en: ""
+
+runtimeClassName: ""

--- a/charts/marimo-python-gpu/.helmignore
+++ b/charts/marimo-python-gpu/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/marimo-python-gpu/Chart.yaml
+++ b/charts/marimo-python-gpu/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: marimo-python-gpu
+description: Marimo reactive Python notebook with Python, and a collection 
+  of standard data science packages, with GPU support.
+icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/marimo.png
+keywords:
+- Marimo
+- Python
+home: https://marimo.io/
+sources:
+- https://github.com/InseeFrLab/images-datascience
+- https://github.com/InseeFrLab/helm-charts-interactive-services
+type: application
+version: 0.0.1
+dependencies:
+- name: library-chart
+  version: 2.0.4
+  repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/marimo-python-gpu/templates/NOTES.txt
+++ b/charts/marimo-python-gpu/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}

--- a/charts/marimo-python-gpu/templates/NOTES.txt
+++ b/charts/marimo-python-gpu/templates/NOTES.txt
@@ -1,1 +1,1 @@
-{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}
+{{- template "library-chart.notes" (dict "serviceName" "Marimo (Python)" "context" $) -}}

--- a/charts/marimo-python-gpu/templates/configmap-repository.yaml
+++ b/charts/marimo-python-gpu/templates/configmap-repository.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapRepository" . }}

--- a/charts/marimo-python-gpu/templates/ingress-user.yaml
+++ b/charts/marimo-python-gpu/templates/ingress-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressUser" . }}

--- a/charts/marimo-python-gpu/templates/ingress.yaml
+++ b/charts/marimo-python-gpu/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingress" . }}

--- a/charts/marimo-python-gpu/templates/networkpolicy-ingress.yaml
+++ b/charts/marimo-python-gpu/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicyIngress" . }}

--- a/charts/marimo-python-gpu/templates/networkpolicy.yaml
+++ b/charts/marimo-python-gpu/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/marimo-python-gpu/templates/pvc.yaml
+++ b/charts/marimo-python-gpu/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/marimo-python-gpu/templates/role-binding-scc.yaml
+++ b/charts/marimo-python-gpu/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/marimo-python-gpu/templates/role-binding.yaml
+++ b/charts/marimo-python-gpu/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/marimo-python-gpu/templates/route-user.yaml
+++ b/charts/marimo-python-gpu/templates/route-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeUser" . }}

--- a/charts/marimo-python-gpu/templates/route.yaml
+++ b/charts/marimo-python-gpu/templates/route.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.route" . }}

--- a/charts/marimo-python-gpu/templates/secret-assistant.yaml
+++ b/charts/marimo-python-gpu/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistant" . }}

--- a/charts/marimo-python-gpu/templates/secret-cacerts.yaml
+++ b/charts/marimo-python-gpu/templates/secret-cacerts.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCacerts" . }}

--- a/charts/marimo-python-gpu/templates/secret-chromadb.yaml
+++ b/charts/marimo-python-gpu/templates/secret-chromadb.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretChromaDB" . }}

--- a/charts/marimo-python-gpu/templates/secret-extraenv.yaml
+++ b/charts/marimo-python-gpu/templates/secret-extraenv.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretExtraEnv" . }}

--- a/charts/marimo-python-gpu/templates/secret-git.yaml
+++ b/charts/marimo-python-gpu/templates/secret-git.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretGit" . }}

--- a/charts/marimo-python-gpu/templates/secret-hive.yaml
+++ b/charts/marimo-python-gpu/templates/secret-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretHive" . }}

--- a/charts/marimo-python-gpu/templates/secret-metaflow.yaml
+++ b/charts/marimo-python-gpu/templates/secret-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMetaflow" . }}

--- a/charts/marimo-python-gpu/templates/secret-milvus.yaml
+++ b/charts/marimo-python-gpu/templates/secret-milvus.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMilvus" . }}

--- a/charts/marimo-python-gpu/templates/secret-mlflow.yaml
+++ b/charts/marimo-python-gpu/templates/secret-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMLFlow" . }}

--- a/charts/marimo-python-gpu/templates/secret-postgresql.yaml
+++ b/charts/marimo-python-gpu/templates/secret-postgresql.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretPostgreSQL" . }}

--- a/charts/marimo-python-gpu/templates/secret-proxy.yaml
+++ b/charts/marimo-python-gpu/templates/secret-proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretProxy" . }}

--- a/charts/marimo-python-gpu/templates/secret-s3.yaml
+++ b/charts/marimo-python-gpu/templates/secret-s3.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretS3" . }}

--- a/charts/marimo-python-gpu/templates/secret-token.yaml
+++ b/charts/marimo-python-gpu/templates/secret-token.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretToken" . }}

--- a/charts/marimo-python-gpu/templates/secret-vault.yaml
+++ b/charts/marimo-python-gpu/templates/secret-vault.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretVault" . }}

--- a/charts/marimo-python-gpu/templates/service.yaml
+++ b/charts/marimo-python-gpu/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/marimo-python-gpu/templates/serviceaccount.yaml
+++ b/charts/marimo-python-gpu/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/marimo-python-gpu/templates/statefulset.yaml
+++ b/charts/marimo-python-gpu/templates/statefulset.yaml
@@ -1,0 +1,316 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if not (.Values.autoscaling).enabled }}
+  {{- if (.Values.global).suspend }}
+  replicas: 0
+  {{- else }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (.Values.git).enabled }}
+        checksum/git: {{ include (print $.Template.BasePath "/secret-git.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.s3).enabled }}
+        checksum/s3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.vault).enabled }}
+        checksum/vault: {{ include (print $.Template.BasePath "/secret-vault.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretHive" .))) }}
+        checksum/hive: {{ include (print $.Template.BasePath "/secret-hive.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMetaflow" .))) }}
+        checksum/metaflow: {{ include (print $.Template.BasePath "/secret-metaflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/secret-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+        checksum/chromadb: {{ include (print $.Template.BasePath "/secret-chromadb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+        checksum/milvus: {{ include (print $.Template.BasePath "/secret-milvus.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+        checksum/postgresql: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "library-chart.repository.enabled"  .) }}
+        checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        checksum/cacerts: {{ .Values.certificates.cacerts | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.runtimeClassName -}}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
+      volumes:
+        - name: config-files
+          emptyDir: {}
+        - name: home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        {{- if (.Values.proxy).enabled }}
+        - name: secret-proxy
+          secret:
+            secretName: {{ include "library-chart.secretNameProxy" . }}
+        {{- end }}
+        {{- if .Values.discovery.hive }}
+        - name: secret-hive
+          secret:
+            secretName: {{ include "library-chart.secretNameHive" . }}
+        {{- end }}
+        {{- if .Values.discovery.metaflow }}
+        - name: secret-metaflow
+          secret:
+            secretName: {{ include "library-chart.secretNameMetaflow" . }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        - name: cacerts
+          secret:
+            secretName: {{ include "library-chart.secretNameCacerts" . }}
+        {{- end }}
+        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistant" . }}
+        {{- end }}
+        - name: token
+          secret:
+            secretName: {{ include "library-chart.secretNameToken" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: make-secrets-writable
+          image: {{ .Values.service.initContainer.image }}
+          imagePullPolicy: {{ .Values.service.initContainer.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              echo 'initContainer make-secrets-writable is started';
+              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              mkdir /dest/continue
+              cp /src/continue/config.yaml /dest/continue/config.yaml
+              {{- end }}
+              {{- if .Values.discovery.hive }}
+              mkdir /dest/hive;
+              cp /src/hive/hive-site.xml /dest/hive/hive-site.xml;
+              {{- end }}
+              {{- if .Values.discovery.metaflow }}
+              mkdir /dest/metaflow;
+              cp /src/metaflow/config.json /dest/metaflow/config.json;
+              {{- end }}
+              {{- if and .Values.certificates .Values.certificates.cacerts }}
+              mkdir /dest/cacerts;
+              {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
+              curl -s $(cat /cacerts/ca-certs.url) -o /tmp/ca.pem
+              {{- else }}
+              cp /cacerts/ca.pem /tmp/ca.pem
+              {{- end }}
+              awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
+              {{- end }}
+          volumeMounts:
+            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            - name: secret-assistant
+              mountPath: /src/continue
+            {{- end }}
+            - name: config-files
+              mountPath: /dest
+            {{- if and .Values.certificates .Values.certificates.cacerts }}
+            - name: cacerts
+              mountPath: /cacerts
+            {{- end }}
+            {{- if .Values.discovery.hive }}
+            - name: secret-hive
+              mountPath: /src/hive
+            {{- end }}
+            {{- if .Values.discovery.metaflow }}
+            - name : secret-metaflow
+              mountPath: /src/metaflow
+            {{- end }}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.service.image.custom.enabled }}
+          image: "{{ .Values.service.image.custom.version }}"
+          {{- else }}
+          image: "{{ .Values.service.image.version }}"
+          {{- end }}
+          command: ["/bin/sh","-c"]
+          {{- if .Values.git.asCodeServerRoot }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
+          {{- else }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
+          {{- end }}
+          imagePullPolicy: {{ .Values.service.image.pullPolicy }}
+          env:
+            {{- if .Values.init.regionInit }}
+            - name: REGION_INIT_SCRIPT
+              value: {{ .Values.init.regionInit }}
+            {{- end }}
+            {{- if .Values.init.regionInitCheckSum }}
+            - name: REGION_INIT_SCRIPT_CHECKSUM
+              value: {{ .Values.init.regionInitCheckSum }}
+            {{- end }}
+            {{- if .Values.init.personalInit }}
+            - name: PERSONAL_INIT_SCRIPT
+              value: {{ .Values.init.personalInit }}
+            {{- end }}
+            {{- if .Values.init.personalInitArgs }}
+            - name: PERSONAL_INIT_ARGS
+              value: {{ .Values.init.personalInitArgs }}
+            {{- end }}
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: ROOT_PROJECT_DIRECTORY
+              value: /home/{{ .Values.environment.user }}/work
+            {{- if .Values.userPreferences.darkMode }}
+            - name: DARK_MODE
+              value: "true"
+            {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
+          envFrom:
+            - secretRef:
+                name : {{ include "library-chart.secretNameToken" . }}
+            {{- if (.Values.git).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameGit" . }}
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameS3" . }}
+            {{- end }}
+            {{- if (.Values.vault).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameVault" . }}
+            {{- end }}
+            {{- if (.Values.proxy).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameProxy" . }}
+            {{- end }}
+            {{- if (include "library-chart.repository.enabled" .) }}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameRepository" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMLFlow" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNamePostgreSQL" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameChromaDB" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMilvus" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameExtraEnv" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 2
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          {{- if hasKey .Values "startupProbe" }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+            - name: token
+              mountPath: /home/{{ .Values.environment.user }}/.token
+              readOnly: true
+            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.continue
+              subPath: continue
+              name: config-files
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: config-files
+              mountPath: /usr/local/lib/hive/conf/hive-site.xml
+              subPath: hive/hive-site.xml
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.metaflowconfig
+              subPath: metaflow
+            {{- end }}
+            {{- if (.Values.certificates).pathToCaBundle }}
+            - name: config-files
+              mountPath: {{ .Values.certificates.pathToCaBundle }}
+              subPath: cacerts
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/marimo-python-gpu/templates/tests/test-connection.yaml
+++ b/charts/marimo-python-gpu/templates/tests/test-connection.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.testConnection" . }}

--- a/charts/marimo-python-gpu/values.schema.json
+++ b/charts/marimo-python-gpu/values.schema.json
@@ -1,0 +1,1143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "service": {
+      "title": "Service",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Docker image",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "title": "Pull image from registry",
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "title": "Name of the service's Docker image",
+              "type": "string",
+              "default": "pacordonnier/marimo-python:py3.13.12-gpu",
+              "listEnum": [
+                "pacordonnier/marimo-python:py3.13.12-gpu",
+                "pacordonnier/marimo-python:py3.12.13-gpu"
+              ],
+              "render": "list",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              }
+            },
+            "custom": {
+              "title": "Custom image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Use a custom image instead",
+                  "type": "boolean",
+                  "default": false,
+                  "x-onyxia": {
+                    "overwriteSchemaWith": "ide/customImage.json"
+                  }
+                },
+                "version": {
+                  "title": "Name of the custom image",
+                  "type": "string",
+                  "default": "pacordonnier/marimo-python:py3.13.12-gpu",
+                  "hidden": {
+                    "value": false,
+                    "path": "enabled",
+                    "isPathRelative": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources (CPU/RAM)",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/resources-gpu.json"
+      },
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Guaranteed CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuRequest",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Guaranteed memory allocation",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryRequest",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Maximum CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuLimit",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Maximum memory allocation",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryLimit",
+                "useRegionSliderConfig": "memory"
+              }
+            },
+            "nvidia.com/gpu": {
+              "description": "GPU to allocate to this instance. This is also requested",
+              "type": "string",
+              "default": "1",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 3,
+              "sliderStep": 1,
+              "sliderUnit": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.gpu",
+                "useRegionSliderConfig": "gpu"
+              }
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/persistence.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Create a persistent volume",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "title": "Persistent volume size",
+          "type": "string",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "overwriteDefaultWith": "region.resources.disk",
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "init": {
+      "title": "Initialization scripts",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/init.json"
+      },
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "regionInitCheckSum": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptCheckSum}}"
+          }
+        },
+        "personalInit": {
+          "title": "Use a custom script (URL)",
+          "type": "string",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "title": "Arguments for the custom script",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "extraEnvVars": {
+      "title": "Environment variables available within your service",
+      "type": "array",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/extraenv.json"
+      },
+      "items": {
+        "title": "",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "VAR_NAME",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "title": "Kubernetes permissions",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/role.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Kubernetes access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "role": {
+          "title": "Kubernetes role",
+          "description": "access is restricted to your own namespace",
+          "type": "string",
+          "default": "view",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "listEnum": [
+            "view",
+            "edit",
+            "admin"
+          ],
+          "render": "list"
+        }
+      }
+    },
+    "openshiftSCC": {
+      "description": "configuration for openshift compatibility",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/openshiftSCC.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "enable rolebinding with openshift scc",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.enabled"
+          }
+        },
+        "scc": {
+          "type": "string",
+          "description": "name of scc for rolebinding",
+          "default": "anyuid",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.scc"
+          }
+        }
+      }
+    },
+    "vault": {
+      "title": "Vault access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/vault.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Vault access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "token": {
+          "title": "Vault token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "url": {
+          "title": "Vault server URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "mount": {
+          "title": "Secret engine",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "directory": {
+          "title": "Top-level directory",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secret": {
+          "title": "Path to the secret to load",
+          "description": "The secret will be converted into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "s3": {
+      "title": "S3 object storage",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/s3.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable S3 access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "accessKeyId": {
+          "title": "Access Key ID",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "s3.AWS_ACCESS_KEY_ID"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "endpoint": {
+          "title": "S3 endpoint URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "defaultRegion": {
+          "title": "Default region",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secretAccessKey": {
+          "title": "Secret Access Key",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "sessionToken": {
+          "title": "Session token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "pathStyleAccess": {
+          "title": "Path-style access",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.pathStyleAccess}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "workingDirectoryPath": {
+          "title": "Working directory path",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.workingDirectoryPath}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "git": {
+      "title": "Git access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/git.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable git access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "title": "User name",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "email": {
+          "title": "User email",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "cache": {
+          "title": "Credentials caching duration",
+          "description": "(in seconds)",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "token": {
+          "title": "Personal Access Token",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "repository": {
+          "title": "Project repository",
+          "description": "cloned in service",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "branch": {
+          "title": "Specific branch to use",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "asCodeServerRoot": {
+          "title": "Open the service in the clone folder",
+          "type": "boolean",
+          "default": false,
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "networking": {
+      "title": "Network access",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/networking.json"
+      },
+      "properties": {
+        "user": {
+          "title": "Ports",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable access to your service through specific ports",
+              "type": "boolean",
+              "default": false
+            },
+            "port": {
+              "title": "Port number to expose",
+              "type": "integer",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            },
+            "ports": {
+              "title": "Port numbers to expose",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "uniqueItems": true,
+                "default": 5000
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "title": "Third party services discovery",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "title": "Discover Hive Metastore services",
+          "type": "boolean",
+          "default": true
+        },
+        "mlflow": {
+          "title": "Discover MLflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "metaflow": {
+          "title": "Discover Metaflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "chromadb": {
+          "title": "Discover ChromaDB services",
+          "type": "boolean",
+          "default": true
+        },
+        "milvus": {
+          "title": "Discover Milvus services",
+          "type": "boolean",
+          "default": true
+        },
+        "postgresql": {
+          "title": "Discover PostgreSQL services",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "security": {
+      "title": "Security",
+      "type": "object",
+      "properties": {
+        "password": {
+          "title": "Service password",
+          "type": "string",
+          "default": "changeme",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{service.oneTimePassword}}",
+            "overwriteSchemaWith": "ide/password.json"
+          }
+        },
+        "networkPolicy": {
+          "title": "Network access policy",
+          "type": "object",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "title": "Only allow access from the same namespace",
+              "type": "boolean",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "description": "Array of sources allowed to have network access to your service",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "NodeSelector",
+      "default": {},
+      "x-onyxia": {
+        "overwriteDefaultWith": "region.nodeSelector",
+        "overwriteSchemaWith": "nodeSelector-gpu.json"
+      }
+    },
+    "ingress": {
+      "title": "Ingress Details",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/ingress.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        },
+        "useCertManager": {
+          "type": "boolean",
+          "description": "Whether CertManager should be used to generate a certificate",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.useCertManager"
+          }
+        },
+        "certManagerClusterIssuer": {
+          "type": "string",
+          "description": "certManager cluster issuer",
+          "title": "CertManager Cluster Issuer",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
+          }
+        },
+        "useTlsSecret": {
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tlsSecretName": {
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "repository.json"
+      },
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
+    },
+    "startupProbe": {
+      "description": "Startup probe",
+      "type": "object",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "default": 60
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "default": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "default": 2
+        }
+      },
+      "default": {
+        "failureThreshold": 60,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "timeoutSeconds": 2
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.startupProbe",
+        "overwriteSchemaWith": "ide/startupProbe.json"
+      }
+    },
+    "tolerations": {
+      "description": "Array of tolerations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "userPreferences": {
+      "title": "User Preferences",
+      "type": "object",
+      "properties": {
+        "darkMode": {
+          "type": "boolean",
+          "description": "dark mode is or is not enabled",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.darkMode"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Preferred language",
+          "default": "en",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.lang"
+          }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Continue, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            },
+            "useLegacyCompletionsEndpoint": {
+              "title": "use legacy completions endpoint",
+              "type": "boolean",
+              "default": true,
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
+              }
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "proxy": {
+      "description": "It can be used to inject proxy settings in the services",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "proxy.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Inject proxy settings",
+          "default": false
+        },
+        "httpProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTP.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTPS.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "enterprise local domain that should not take proxy comma separated",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "description": "It can be used to inject certificate authority into the services, if the Helm chart in the catalog allows it you can bind this value to the Helm chart value to add some certificate authorities in the pod.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "certificates.json"
+      },
+      "default": {},
+      "properties": {
+        "cacerts": {
+          "type": "string",
+          "description": "String of concatenated CA certificates. Alternatively a target URL can be provided.",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "pathToCaBundle": {
+          "type": "string",
+          "description": "String path where a bundle is made or injected by third party solution",
+          "default": "/usr/local/share/ca-certificates/",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "Warning message",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/message.json"
+      },
+      "properties": {
+        "fr": {
+          "type": "string",
+          "description": "message \u00e0 ajouter dans les notes",
+          "default": ""
+        },
+        "en": {
+          "type": "string",
+          "description": "message to add in notes",
+          "default": ""
+        }
+      }
+    },
+    "runtimeClassName": {
+      "type": "string",
+      "description": "Runtime Class Name",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/runtimeClassName.json"
+      }
+    }
+  }
+}

--- a/charts/marimo-python-gpu/values.yaml
+++ b/charts/marimo-python-gpu/values.yaml
@@ -1,0 +1,169 @@
+global:
+  suspend: false
+service:
+  initContainer:
+    image: inseefrlab/onyxia-base:latest
+    pullPolicy: IfNotPresent
+  image:
+    version: pacordonnier/marimo-python:py3.13.12-gpu
+    pullPolicy: IfNotPresent
+    custom:
+      enabled: false
+      version: pacordonnier/marimo-python:py3.13.12-gpu
+security:
+  password: changeme
+  networkPolicy:
+    enabled: false
+    from: []
+  allowlist:
+    enabled: false
+    ip: 0.0.0.0/0
+init:
+  standardInitPath: /opt/onyxia-init.sh
+  regionInit: ''
+  regionInitCheckSum: ''
+  personalInit: ''
+  personalInitArgs: ''
+extraEnvVars: []
+s3:
+  enabled: false
+  secretName: ''
+  accessKeyId: ''
+  endpoint: ''
+  defaultRegion: ''
+  secretAccessKey: ''
+  sessionToken: ''
+  pathStyleAccess: false
+  workingDirectoryPath: ''
+vault:
+  enabled: false
+  secretName: ''
+  token: ''
+  url: ''
+  mount: ''
+  secret: ''
+  directory: ''
+git:
+  enabled: true
+  secretName: ''
+  name: ''
+  email: ''
+  cache: ''
+  branch: ''
+  asCodeServerRoot: false
+repository:
+  configMapName: ''
+  pipRepository: ''
+  condaRepository: ''
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+  chromadb: true
+  milvus: true
+  postgresql: true
+hive:
+  secretName: ''
+mlflow:
+  secretName: ''
+metaflow:
+  secretName: ''
+chromadb:
+  secretName: ''
+milvus:
+  secretName: ''
+coresite:
+  secretName: ''
+postgresql:
+  secretName: ''
+replicaCount: 1
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ''
+environment:
+  user: onyxia
+  group: users
+kubernetes:
+  enabled: true
+  role: view
+podAnnotations: {}
+podSecurityContext:
+  fsGroup: 100
+securityContext: {}
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    port: 2718
+  user:
+    enabled: false
+    port: 5000
+    ports: []
+ingress:
+  enabled: false
+  tls: true
+  ingressClassName: ''
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  path: /
+  userPath: /
+  useCertManager: false
+  certManagerClusterIssuer: ''
+  useTlsSecret: false
+  tlsSecretName: ''
+route:
+  enabled: false
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  tls:
+    termination: edge
+  wildcardPolicy: None
+resources: {}
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 10Gi
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+nodeSelector: {}
+tolerations: []
+affinity: {}
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+userPreferences:
+  darkMode: false
+  language: en
+  aiAssistant:
+    enabled: false
+    model: ''
+    provider: ''
+    apiBase: ''
+    apiKey: ''
+    secretName: ''
+    useLegacyCompletionsEndpoint: false
+openshiftSCC:
+  enabled: false
+  scc: ''
+proxy:
+  enabled: false
+  noProxy: ''
+  httpProxy: ''
+  httpsProxy: ''
+certificates: {}
+message:
+  fr: ''
+  en: ''
+runtimeClassName: ''

--- a/charts/marimo-python/.helmignore
+++ b/charts/marimo-python/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/marimo-python/Chart.yaml
+++ b/charts/marimo-python/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: marimo-python
+description: Marimo reactive Python notebook with Python, and a collection of standard data science packages
+icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/marimo.png
+keywords:
+  - Marimo
+  - Python
+home: https://marimo.io/
+sources:
+  - https://github.com/InseeFrLab/images-datascience
+  - https://github.com/InseeFrLab/helm-charts-interactive-services
+type: application
+version: 0.0.1
+dependencies:
+  - name: library-chart
+    version: 2.0.1
+    repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/marimo-python/templates/NOTES.txt
+++ b/charts/marimo-python/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- template "library-chart.notes" (dict "serviceName" "Marimo (Python)" "context" $) -}}

--- a/charts/marimo-python/templates/configmap-repository.yaml
+++ b/charts/marimo-python/templates/configmap-repository.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapRepository" . }}

--- a/charts/marimo-python/templates/ingress-user.yaml
+++ b/charts/marimo-python/templates/ingress-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressUser" . }}

--- a/charts/marimo-python/templates/ingress.yaml
+++ b/charts/marimo-python/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingress" . }}

--- a/charts/marimo-python/templates/networkpolicy-ingress.yaml
+++ b/charts/marimo-python/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicyIngress" . }}

--- a/charts/marimo-python/templates/networkpolicy.yaml
+++ b/charts/marimo-python/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/marimo-python/templates/pvc.yaml
+++ b/charts/marimo-python/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/marimo-python/templates/role-binding-scc.yaml
+++ b/charts/marimo-python/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/marimo-python/templates/role-binding.yaml
+++ b/charts/marimo-python/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/marimo-python/templates/route-user.yaml
+++ b/charts/marimo-python/templates/route-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeUser" . }}

--- a/charts/marimo-python/templates/route.yaml
+++ b/charts/marimo-python/templates/route.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.route" . }}

--- a/charts/marimo-python/templates/secret-assistant.yaml
+++ b/charts/marimo-python/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistant" . }}

--- a/charts/marimo-python/templates/secret-cacerts.yaml
+++ b/charts/marimo-python/templates/secret-cacerts.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCacerts" . }}

--- a/charts/marimo-python/templates/secret-chromadb.yaml
+++ b/charts/marimo-python/templates/secret-chromadb.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretChromaDB" . }}

--- a/charts/marimo-python/templates/secret-extraenv.yaml
+++ b/charts/marimo-python/templates/secret-extraenv.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretExtraEnv" . }}

--- a/charts/marimo-python/templates/secret-git.yaml
+++ b/charts/marimo-python/templates/secret-git.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretGit" . }}

--- a/charts/marimo-python/templates/secret-hive.yaml
+++ b/charts/marimo-python/templates/secret-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretHive" . }}

--- a/charts/marimo-python/templates/secret-metaflow.yaml
+++ b/charts/marimo-python/templates/secret-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMetaflow" . }}

--- a/charts/marimo-python/templates/secret-milvus.yaml
+++ b/charts/marimo-python/templates/secret-milvus.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMilvus" . }}

--- a/charts/marimo-python/templates/secret-mlflow.yaml
+++ b/charts/marimo-python/templates/secret-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMLFlow" . }}

--- a/charts/marimo-python/templates/secret-postgresql.yaml
+++ b/charts/marimo-python/templates/secret-postgresql.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretPostgreSQL" . }}

--- a/charts/marimo-python/templates/secret-proxy.yaml
+++ b/charts/marimo-python/templates/secret-proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretProxy" . }}

--- a/charts/marimo-python/templates/secret-s3.yaml
+++ b/charts/marimo-python/templates/secret-s3.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretS3" . }}

--- a/charts/marimo-python/templates/secret-token.yaml
+++ b/charts/marimo-python/templates/secret-token.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretToken" . }}

--- a/charts/marimo-python/templates/secret-vault.yaml
+++ b/charts/marimo-python/templates/secret-vault.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretVault" . }}

--- a/charts/marimo-python/templates/service.yaml
+++ b/charts/marimo-python/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/marimo-python/templates/serviceaccount.yaml
+++ b/charts/marimo-python/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/marimo-python/templates/statefulset.yaml
+++ b/charts/marimo-python/templates/statefulset.yaml
@@ -1,0 +1,313 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if not (.Values.autoscaling).enabled }}
+  {{- if (.Values.global).suspend }}
+  replicas: 0
+  {{- else }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (.Values.git).enabled }}
+        checksum/git: {{ include (print $.Template.BasePath "/secret-git.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.s3).enabled }}
+        checksum/s3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.vault).enabled }}
+        checksum/vault: {{ include (print $.Template.BasePath "/secret-vault.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretHive" .))) }}
+        checksum/hive: {{ include (print $.Template.BasePath "/secret-hive.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMetaflow" .))) }}
+        checksum/metaflow: {{ include (print $.Template.BasePath "/secret-metaflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/secret-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+        checksum/chromadb: {{ include (print $.Template.BasePath "/secret-chromadb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+        checksum/milvus: {{ include (print $.Template.BasePath "/secret-milvus.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+        checksum/postgresql: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "library-chart.repository.enabled"  .) }}
+        checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        checksum/cacerts: {{ .Values.certificates.cacerts | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      volumes:
+        - name: config-files
+          emptyDir: {}
+        - name: home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        {{- if (.Values.proxy).enabled }}
+        - name: secret-proxy
+          secret:
+            secretName: {{ include "library-chart.secretNameProxy" . }}
+        {{- end }}
+        {{- if .Values.discovery.hive }}
+        - name: secret-hive
+          secret:
+            secretName: {{ include "library-chart.secretNameHive" . }}
+        {{- end }}
+        {{- if .Values.discovery.metaflow }}
+        - name: secret-metaflow
+          secret:
+            secretName: {{ include "library-chart.secretNameMetaflow" . }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        - name: cacerts
+          secret:
+            secretName: {{ include "library-chart.secretNameCacerts" . }}
+        {{- end }}
+        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistant" . }}
+        {{- end }}
+        - name: token
+          secret:
+            secretName: {{ include "library-chart.secretNameToken" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: make-secrets-writable
+          image: {{ .Values.service.initContainer.image }}
+          imagePullPolicy: {{ .Values.service.initContainer.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              echo 'initContainer make-secrets-writable is started';
+              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              mkdir /dest/continue
+              cp /src/continue/config.yaml /dest/continue/config.yaml
+              {{- end }}
+              {{- if .Values.discovery.hive }}
+              mkdir /dest/hive;
+              cp /src/hive/hive-site.xml /dest/hive/hive-site.xml;
+              {{- end }}
+              {{- if .Values.discovery.metaflow }}
+              mkdir /dest/metaflow;
+              cp /src/metaflow/config.json /dest/metaflow/config.json;
+              {{- end }}
+              {{- if and .Values.certificates .Values.certificates.cacerts }}
+              mkdir /dest/cacerts;
+              {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
+              curl -s $(cat /cacerts/ca-certs.url) -o /tmp/ca.pem
+              {{- else }}
+              cp /cacerts/ca.pem /tmp/ca.pem
+              {{- end }}
+              awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
+              {{- end }}
+          volumeMounts:
+            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            - name: secret-assistant
+              mountPath: /src/continue
+            {{- end }}
+            - name: config-files
+              mountPath: /dest
+            {{- if and .Values.certificates .Values.certificates.cacerts }}
+            - name: cacerts
+              mountPath: /cacerts
+            {{- end }}
+            {{- if .Values.discovery.hive }}
+            - name: secret-hive
+              mountPath: /src/hive
+            {{- end }}
+            {{- if .Values.discovery.metaflow }}
+            - name : secret-metaflow
+              mountPath: /src/metaflow
+            {{- end }}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.service.image.custom.enabled }}
+          image: "{{ .Values.service.image.custom.version }}"
+          {{- else }}
+          image: "{{ .Values.service.image.version }}"
+          {{- end }}
+          command: ["/bin/sh","-c"]
+          {{- if .Values.git.asCodeServerRoot }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
+          {{- else }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
+          {{- end }}
+          imagePullPolicy: {{ .Values.service.image.pullPolicy }}
+          env:
+            {{- if .Values.init.regionInit }}
+            - name: REGION_INIT_SCRIPT
+              value: {{ .Values.init.regionInit }}
+            {{- end }}
+            {{- if .Values.init.regionInitCheckSum }}
+            - name: REGION_INIT_SCRIPT_CHECKSUM
+              value: {{ .Values.init.regionInitCheckSum }}
+            {{- end }}
+            {{- if .Values.init.personalInit }}
+            - name: PERSONAL_INIT_SCRIPT
+              value: {{ .Values.init.personalInit }}
+            {{- end }}
+            {{- if .Values.init.personalInitArgs }}
+            - name: PERSONAL_INIT_ARGS
+              value: {{ .Values.init.personalInitArgs }}
+            {{- end }}
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: ROOT_PROJECT_DIRECTORY
+              value: /home/{{ .Values.environment.user }}/work
+            {{- if .Values.userPreferences.darkMode }}
+            - name: DARK_MODE
+              value: "true"
+            {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
+          envFrom:
+            - secretRef:
+                name : {{ include "library-chart.secretNameToken" . }}
+            {{- if (.Values.git).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameGit" . }}
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameS3" . }}
+            {{- end }}
+            {{- if (.Values.vault).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameVault" . }}
+            {{- end }}
+            {{- if (.Values.proxy).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameProxy" . }}
+            {{- end }}
+            {{- if (include "library-chart.repository.enabled" .) }}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameRepository" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMLFlow" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNamePostgreSQL" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameChromaDB" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMilvus" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameExtraEnv" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 2
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          {{- if hasKey .Values "startupProbe" }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+            - name: token
+              mountPath: /home/{{ .Values.environment.user }}/.token
+              readOnly: true
+            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.continue
+              subPath: continue
+              name: config-files
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: config-files
+              mountPath: /usr/local/lib/hive/conf/hive-site.xml
+              subPath: hive/hive-site.xml
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.metaflowconfig
+              subPath: metaflow
+            {{- end }}
+            {{- if (.Values.certificates).pathToCaBundle }}
+            - name: config-files
+              mountPath: {{ .Values.certificates.pathToCaBundle }}
+              subPath: cacerts
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/marimo-python/templates/tests/test-connection.yaml
+++ b/charts/marimo-python/templates/tests/test-connection.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.testConnection" . }}

--- a/charts/marimo-python/values.schema.json
+++ b/charts/marimo-python/values.schema.json
@@ -1,0 +1,1124 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "service": {
+      "title": "Service",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Docker image",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "title": "Pull image from registry",
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "title": "Name of the service's Docker image",
+              "type": "string",
+              "default": "pacordonnier/marimo-python:py3.13.13",
+              "listEnum": [
+                "pacordonnier/marimo-python:py3.13.13",
+                "pacordonnier/marimo-python:py3.12.13"
+              ],
+              "render": "list",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              }
+            },
+            "custom": {
+              "title": "Custom image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Use a custom image instead",
+                  "type": "boolean",
+                  "default": false,
+                  "x-onyxia": {
+                    "overwriteSchemaWith": "ide/customImage.json"
+                  }
+                },
+                "version": {
+                  "title": "Name of the custom image",
+                  "type": "string",
+                  "default": "pacordonnier/marimo:latest",
+                  "hidden": {
+                    "value": false,
+                    "path": "enabled",
+                    "isPathRelative": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources (CPU/RAM)",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/resources.json"
+      },
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Guaranteed CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuRequest",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Guaranteed memory allocation",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryRequest",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Maximum CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuLimit",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Maximum memory allocation",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryLimit",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/persistence.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Create a persistent volume",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "title": "Persistent volume size",
+          "type": "string",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "overwriteDefaultWith": "region.resources.disk",
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "init": {
+      "title": "Initialization scripts",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/init.json"
+      },
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "regionInitCheckSum": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptCheckSum}}"
+          }
+        },
+        "personalInit": {
+          "title": "Use a custom script (URL)",
+          "type": "string",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "title": "Arguments for the custom script",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "extraEnvVars": {
+      "title": "Environment variables available within your service",
+      "type": "array",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/extraenv.json"
+      },
+      "items": {
+        "title": "",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "VAR_NAME",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "title": "Kubernetes permissions",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/role.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Kubernetes access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "role": {
+          "title": "Kubernetes role",
+          "description": "access is restricted to your own namespace",
+          "type": "string",
+          "default": "view",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "listEnum": [
+            "view",
+            "edit",
+            "admin"
+          ],
+          "render": "list"
+        }
+      }
+    },
+    "openshiftSCC": {
+      "description": "configuration for openshift compatibility",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/openshiftSCC.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "enable rolebinding with openshift scc",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.enabled"
+          }
+        },
+        "scc": {
+          "type": "string",
+          "description": "name of scc for rolebinding",
+          "default": "anyuid",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.scc"
+          }
+        }
+      }
+    },
+    "vault": {
+      "title": "Vault access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/vault.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Vault access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "token": {
+          "title": "Vault token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "url": {
+          "title": "Vault server URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "mount": {
+          "title": "Secret engine",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "directory": {
+          "title": "Top-level directory",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secret": {
+          "title": "Path to the secret to load",
+          "description": "The secret will be converted into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "s3": {
+      "title": "S3 object storage",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/s3.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable S3 access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "accessKeyId": {
+          "title": "Access Key ID",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "s3.AWS_ACCESS_KEY_ID"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "endpoint": {
+          "title": "S3 endpoint URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "defaultRegion": {
+          "title": "Default region",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secretAccessKey": {
+          "title": "Secret Access Key",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "sessionToken": {
+          "title": "Session token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "pathStyleAccess": {
+          "title": "Path-style access",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.pathStyleAccess}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "workingDirectoryPath": {
+          "title": "Working directory path",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.workingDirectoryPath}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "git": {
+      "title": "Git access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/git.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable git access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "title": "User name",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "email": {
+          "title": "User email",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "cache": {
+          "title": "Credentials caching duration",
+          "description": "(in seconds)",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "token": {
+          "title": "Personal Access Token",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "repository": {
+          "title": "Project repository",
+          "description": "cloned in service",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "branch": {
+          "title": "Specific branch to use",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "asCodeServerRoot": {
+          "title": "Open the service in the clone folder",
+          "type": "boolean",
+          "default": false,
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "networking": {
+      "title": "Network access",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/networking.json"
+      },
+      "properties": {
+        "user": {
+          "title": "Ports",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable access to your service through specific ports",
+              "type": "boolean",
+              "default": false
+            },
+            "port": {
+              "title": "Port number to expose",
+              "type": "integer",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            },
+            "ports": {
+              "title": "Port numbers to expose",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "uniqueItems": true,
+                "default": 5000
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "title": "Third party services discovery",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "title": "Discover Hive Metastore services",
+          "type": "boolean",
+          "default": true
+        },
+        "mlflow": {
+          "title": "Discover MLflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "metaflow": {
+          "title": "Discover Metaflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "chromadb": {
+          "title": "Discover ChromaDB services",
+          "type": "boolean",
+          "default": true
+        },
+        "milvus": {
+          "title": "Discover Milvus services",
+          "type": "boolean",
+          "default": true
+        },
+        "postgresql": {
+          "title": "Discover PostgreSQL services",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "security": {
+      "title": "Security",
+      "type": "object",
+      "properties": {
+        "password": {
+          "title": "Service password",
+          "type": "string",
+          "default": "changeme",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{service.oneTimePassword}}",
+            "overwriteSchemaWith": "ide/password.json"
+          }
+        },
+        "networkPolicy": {
+          "title": "Network access policy",
+          "type": "object",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "title": "Only allow access from the same namespace",
+              "type": "boolean",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "description": "Array of sources allowed to have network access to your service",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "title": "Node selector",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      },
+      "x-onyxia": {
+        "hidden": false,
+        "overwriteDefaultWith": "region.nodeSelector",
+        "overwriteSchemaWith": "nodeSelector.json"
+      }
+    },
+    "ingress": {
+      "title": "Ingress Details",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/ingress.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        },
+        "useCertManager": {
+          "type": "boolean",
+          "description": "Whether CertManager should be used to generate a certificate",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.useCertManager"
+          }
+        },
+        "certManagerClusterIssuer": {
+          "type": "string",
+          "description": "certManager cluster issuer",
+          "title": "CertManager Cluster Issuer",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
+          }
+        },
+        "useTlsSecret": {
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tlsSecretName":{
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "repository.json"
+      },
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
+    },
+    "startupProbe": {
+      "description": "Startup probe",
+      "type": "object",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "default": 60
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "default": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "default": 2
+        }
+      },
+      "default": {
+        "failureThreshold": 60,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "timeoutSeconds": 2
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.startupProbe",
+        "overwriteSchemaWith": "ide/startupProbe.json"
+      }
+    },
+    "tolerations": {
+      "description": "Array of tolerations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "userPreferences": {
+      "title": "User Preferences",
+      "type": "object",
+      "properties": {
+        "darkMode": {
+          "type": "boolean",
+          "description": "dark mode is or is not enabled",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.darkMode"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Preferred language",
+          "default": "en",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.lang"
+          }
+        },
+        "aiAssistant":{
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Continue, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default":"",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase":{
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey":{
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            },
+            "useLegacyCompletionsEndpoint":{
+              "title": "use legacy completions endpoint",
+              "type": "boolean",
+              "default": true,
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
+              }
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "proxy": {
+      "description": "It can be used to inject proxy settings in the services",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "proxy.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Inject proxy settings",
+          "default": false
+        },
+        "httpProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTP.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTPS.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "enterprise local domain that should not take proxy comma separated",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "description": "It can be used to inject certificate authority into the services, if the Helm chart in the catalog allows it you can bind this value to the Helm chart value to add some certificate authorities in the pod.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "certificates.json"
+      },
+      "default": {},
+      "properties": {
+        "cacerts": {
+          "type": "string",
+          "description": "String of concatenated CA certificates. Alternatively a target URL can be provided.",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "pathToCaBundle": {
+          "type": "string",
+          "description": "String path where a bundle is made or injected by third party solution",
+          "default": "/usr/local/share/ca-certificates/",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "Warning message",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/message.json"
+      },
+      "properties": {
+        "fr": {
+          "type": "string",
+          "description": "message à ajouter dans les notes",
+          "default": ""
+        },
+        "en": {
+          "type": "string",
+          "description": "message to add in notes",
+          "default": ""
+        }
+      }
+    }
+  }
+}

--- a/charts/marimo-python/values.yaml
+++ b/charts/marimo-python/values.yaml
@@ -1,0 +1,270 @@
+# Default values for marimo.
+global:
+  suspend: false
+
+service:
+  initContainer:
+    image: "inseefrlab/onyxia-base:latest"
+    pullPolicy: IfNotPresent
+  image:
+    version: "pacordonnier/marimo-python:py3.13.12"
+    pullPolicy: IfNotPresent
+    custom:
+      enabled: false
+      version: "pacordonnier/marimo-python:py3.13.12"
+security:
+  password: "changeme"
+  networkPolicy:
+    enabled: false
+    from: []
+  allowlist:
+    enabled: false
+    ip: "0.0.0.0/0"
+
+init:
+  standardInitPath: "/opt/onyxia-init.sh"
+  regionInit: ""
+  regionInitCheckSum: ""
+  personalInit: ""
+  personalInitArgs: ""
+
+# Array with (templated) extra environment variables to be made accessible within the service
+# e.g:
+# extraEnvVars:
+#   - name: FOO
+#     value: "bar"
+extraEnvVars: []
+
+s3:
+  # Specifies whether S3 credentials should be made available
+  enabled: false
+  # The name of the secret storing the S3 credentials
+  secretName: ""  # Generated based on the service's name if empty or not set
+  accessKeyId: ""
+  endpoint: ""
+  defaultRegion: ""
+  secretAccessKey: ""
+  sessionToken: ""
+  pathStyleAccess: false
+  workingDirectoryPath: ""
+
+vault:
+  # Specifies whether Vault credentials should be made available
+  enabled: false
+  # The name of the secret storing the Vault credentials
+  secretName: ""  # Generated based on the service's name if empty or not set
+  token: ""
+  url: ""
+  mount: ""
+  secret: ""
+  directory: ""
+
+git:
+  # Specifies whether git credentials should be made available
+  enabled: true
+  # The name of the secret storing the git credentials
+  secretName: ""  # Generated based on the service's name if empty or not set
+  name: ""
+  email: ""
+  cache: ""
+  branch: ""
+  asCodeServerRoot: false
+
+repository:
+  configMapName: ""
+  pipRepository: ""
+  condaRepository: ""
+
+# active ou non la recherche de secrets discovery dans le namespace
+# see secret-{service}.yaml
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+  chromadb: true
+  milvus: true
+  postgresql: true
+
+hive:
+  secretName: ""
+
+mlflow:
+  secretName: ""
+
+metaflow:
+  secretName: ""
+
+chromadb:
+  secretName: ""
+
+milvus:
+  secretName: ""
+
+coresite:
+  secretName: ""
+
+postgresql:
+  secretName: ""
+
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+environment:
+  user: onyxia
+  group: users
+
+kubernetes:
+  enabled: true
+  role: "view"
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 100
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    port: 2718
+  # Custom user-specified extra ports exposition.
+  # If ingress or route is enabled, the exposed ports are also made available at the
+  # {ingress,route}.userHostname URL (or variations, in case several ports are provided).
+  # Note: a non-empty networking.user.ports overrides networking.user.port
+  user:
+    enabled: false
+    port: 5000
+    ports: []
+
+ingress:
+  enabled: false
+  tls: true
+  ingressClassName: ""
+  annotations: []
+    # kubernetes.io/tls-acme: "true"
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  path: /
+  userPath: /
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+  useCertManager: false
+  certManagerClusterIssuer: ""
+  useTlsSecret: false
+  tlsSecretName: ""
+
+
+route:
+  enabled: false
+  annotations: []
+    # route.openshift.io/termination: "reencrypt"
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  tls:
+    termination: edge
+    # key:
+    # certificate:
+    # caCertificate:
+    # destinationCACertificate:
+  wildcardPolicy: None
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+persistence:
+  enabled: true
+  ## database data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 10Gi
+  # existingClaim: ""
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+
+userPreferences:
+  darkMode: false
+  language: "en"
+  aiAssistant:
+    enabled: false
+    model: ""
+    provider: ""
+    apiBase: ""
+    apiKey: ""
+    secretName: ""  # Generated based on the service's name if empty or not set
+    useLegacyCompletionsEndpoint: false
+
+openshiftSCC:
+  enabled: false
+  scc: ""
+
+proxy:
+  enabled: false
+  noProxy: ""
+  httpProxy: ""
+  httpsProxy: ""
+
+certificates: {}
+  # pathToCaBundle: /usr/local/share/ca-certificates/
+  # cacerts: ""
+
+message:
+  fr: ""
+  en: ""

--- a/charts/marimo-pytorch-gpu/.helmignore
+++ b/charts/marimo-pytorch-gpu/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/marimo-pytorch-gpu/Chart.yaml
+++ b/charts/marimo-pytorch-gpu/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: marimo-pytorch-gpu
+description: Marimo reactive Python notebook with Python and the deep-learning framework PyTorch, with
+  GPU support.
+icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/marimo.png
+keywords:
+- Marimo
+- Python
+home: https://marimo.io/
+sources:
+- https://github.com/InseeFrLab/images-datascience
+- https://github.com/InseeFrLab/helm-charts-interactive-services
+type: application
+version: 0.0.1
+dependencies:
+- name: library-chart
+  version: 2.0.4
+  repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/marimo-pytorch-gpu/templates/NOTES.txt
+++ b/charts/marimo-pytorch-gpu/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}

--- a/charts/marimo-pytorch-gpu/templates/NOTES.txt
+++ b/charts/marimo-pytorch-gpu/templates/NOTES.txt
@@ -1,1 +1,1 @@
-{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}
+{{- template "library-chart.notes" (dict "serviceName" "Marimo (Python)" "context" $) -}}

--- a/charts/marimo-pytorch-gpu/templates/configmap-repository.yaml
+++ b/charts/marimo-pytorch-gpu/templates/configmap-repository.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapRepository" . }}

--- a/charts/marimo-pytorch-gpu/templates/ingress-user.yaml
+++ b/charts/marimo-pytorch-gpu/templates/ingress-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressUser" . }}

--- a/charts/marimo-pytorch-gpu/templates/ingress.yaml
+++ b/charts/marimo-pytorch-gpu/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingress" . }}

--- a/charts/marimo-pytorch-gpu/templates/networkpolicy-ingress.yaml
+++ b/charts/marimo-pytorch-gpu/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicyIngress" . }}

--- a/charts/marimo-pytorch-gpu/templates/networkpolicy.yaml
+++ b/charts/marimo-pytorch-gpu/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/marimo-pytorch-gpu/templates/pvc.yaml
+++ b/charts/marimo-pytorch-gpu/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/marimo-pytorch-gpu/templates/role-binding-scc.yaml
+++ b/charts/marimo-pytorch-gpu/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/marimo-pytorch-gpu/templates/role-binding.yaml
+++ b/charts/marimo-pytorch-gpu/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/marimo-pytorch-gpu/templates/route-user.yaml
+++ b/charts/marimo-pytorch-gpu/templates/route-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeUser" . }}

--- a/charts/marimo-pytorch-gpu/templates/route.yaml
+++ b/charts/marimo-pytorch-gpu/templates/route.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.route" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-assistant.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistant" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-cacerts.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-cacerts.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCacerts" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-chromadb.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-chromadb.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretChromaDB" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-extraenv.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-extraenv.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretExtraEnv" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-git.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-git.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretGit" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-hive.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretHive" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-metaflow.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMetaflow" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-milvus.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-milvus.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMilvus" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-mlflow.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMLFlow" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-postgresql.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-postgresql.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretPostgreSQL" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-proxy.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretProxy" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-s3.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-s3.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretS3" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-token.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-token.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretToken" . }}

--- a/charts/marimo-pytorch-gpu/templates/secret-vault.yaml
+++ b/charts/marimo-pytorch-gpu/templates/secret-vault.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretVault" . }}

--- a/charts/marimo-pytorch-gpu/templates/service.yaml
+++ b/charts/marimo-pytorch-gpu/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/marimo-pytorch-gpu/templates/serviceaccount.yaml
+++ b/charts/marimo-pytorch-gpu/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/marimo-pytorch-gpu/templates/statefulset.yaml
+++ b/charts/marimo-pytorch-gpu/templates/statefulset.yaml
@@ -1,0 +1,313 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if not (.Values.autoscaling).enabled }}
+  {{- if (.Values.global).suspend }}
+  replicas: 0
+  {{- else }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (.Values.git).enabled }}
+        checksum/git: {{ include (print $.Template.BasePath "/secret-git.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.s3).enabled }}
+        checksum/s3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.vault).enabled }}
+        checksum/vault: {{ include (print $.Template.BasePath "/secret-vault.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretHive" .))) }}
+        checksum/hive: {{ include (print $.Template.BasePath "/secret-hive.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMetaflow" .))) }}
+        checksum/metaflow: {{ include (print $.Template.BasePath "/secret-metaflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/secret-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+        checksum/chromadb: {{ include (print $.Template.BasePath "/secret-chromadb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+        checksum/milvus: {{ include (print $.Template.BasePath "/secret-milvus.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+        checksum/postgresql: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "library-chart.repository.enabled"  .) }}
+        checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        checksum/cacerts: {{ .Values.certificates.cacerts | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.runtimeClassName -}}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
+      volumes:
+        - name: config-files
+          emptyDir: {}
+        - name: home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        {{- if (.Values.proxy).enabled }}
+        - name: secret-proxy
+          secret:
+            secretName: {{ include "library-chart.secretNameProxy" . }}
+        {{- end }}
+        {{- if .Values.discovery.hive }}
+        - name: secret-hive
+          secret:
+            secretName: {{ include "library-chart.secretNameHive" . }}
+        {{- end }}
+        {{- if .Values.discovery.metaflow }}
+        - name: secret-metaflow
+          secret:
+            secretName: {{ include "library-chart.secretNameMetaflow" . }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        - name: cacerts
+          secret:
+            secretName: {{ include "library-chart.secretNameCacerts" . }}
+        {{- end }}
+        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistant" . }}
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: make-secrets-writable
+          image: {{ .Values.service.initContainer.image }}
+          imagePullPolicy: {{ .Values.service.initContainer.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              echo 'initContainer make-secrets-writable is started';
+              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              mkdir /dest/continue
+              cp /src/continue/config.yaml /dest/continue/config.yaml
+              {{- end }}
+              {{- if .Values.discovery.hive }}
+              mkdir /dest/hive;
+              cp /src/hive/hive-site.xml /dest/hive/hive-site.xml;
+              {{- end }}
+              {{- if .Values.discovery.metaflow }}
+              mkdir /dest/metaflow;
+              cp /src/metaflow/config.json /dest/metaflow/config.json;
+              {{- end }}
+              {{- if and .Values.certificates .Values.certificates.cacerts }}
+              mkdir /dest/cacerts;
+              {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
+              curl -s $(cat /cacerts/ca-certs.url) -o /tmp/ca.pem
+              {{- else }}
+              cp /cacerts/ca.pem /tmp/ca.pem
+              {{- end }}
+              awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
+              {{- end }}
+          volumeMounts:
+            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            - name: secret-assistant
+              mountPath: /src/continue
+            {{- end }}
+            - name: config-files
+              mountPath: /dest
+            {{- if and .Values.certificates .Values.certificates.cacerts }}
+            - name: cacerts
+              mountPath: /cacerts
+            {{- end }}
+            {{- if .Values.discovery.hive }}
+            - name: secret-hive
+              mountPath: /src/hive
+            {{- end }}
+            {{- if .Values.discovery.metaflow }}
+            - name : secret-metaflow
+              mountPath: /src/metaflow
+            {{- end }}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.service.image.custom.enabled }}
+          image: "{{ .Values.service.image.custom.version }}"
+          {{- else }}
+          image: "{{ .Values.service.image.version }}"
+          {{- end }}
+          command: ["/bin/sh","-c"]
+          {{- if .Values.git.asCodeServerRoot }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
+          {{- else }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
+          {{- end }}
+          imagePullPolicy: {{ .Values.service.image.pullPolicy }}
+          env:
+            {{- if .Values.init.regionInit }}
+            - name: REGION_INIT_SCRIPT
+              value: {{ .Values.init.regionInit }}
+            {{- end }}
+            {{- if .Values.init.regionInitCheckSum }}
+            - name: REGION_INIT_SCRIPT_CHECKSUM
+              value: {{ .Values.init.regionInitCheckSum }}
+            {{- end }}
+            {{- if .Values.init.personalInit }}
+            - name: PERSONAL_INIT_SCRIPT
+              value: {{ .Values.init.personalInit }}
+            {{- end }}
+            {{- if .Values.init.personalInitArgs }}
+            - name: PERSONAL_INIT_ARGS
+              value: {{ .Values.init.personalInitArgs }}
+            {{- end }}
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: ROOT_PROJECT_DIRECTORY
+              value: /home/{{ .Values.environment.user }}/work
+            {{- if .Values.userPreferences.darkMode }}
+            - name: DARK_MODE
+              value: "true"
+            {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
+          envFrom:
+            - secretRef:
+                name : {{ include "library-chart.secretNameToken" . }}
+            {{- if (.Values.git).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameGit" . }}
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameS3" . }}
+            {{- end }}
+            {{- if (.Values.vault).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameVault" . }}
+            {{- end }}
+            {{- if (.Values.proxy).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameProxy" . }}
+            {{- end }}
+            {{- if (include "library-chart.repository.enabled" .) }}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameRepository" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMLFlow" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNamePostgreSQL" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameChromaDB" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMilvus" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameExtraEnv" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 2
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          {{- if hasKey .Values "startupProbe" }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+            - name: token
+              mountPath: /home/{{ .Values.environment.user }}/.token
+              readOnly: true
+            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.continue
+              subPath: continue
+              name: config-files
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: config-files
+              mountPath: /usr/local/lib/hive/conf/hive-site.xml
+              subPath: hive/hive-site.xml
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.metaflowconfig
+              subPath: metaflow
+            {{- end }}
+            {{- if (.Values.certificates).pathToCaBundle }}
+            - name: config-files
+              mountPath: {{ .Values.certificates.pathToCaBundle }}
+              subPath: cacerts
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/marimo-pytorch-gpu/templates/tests/test-connection.yaml
+++ b/charts/marimo-pytorch-gpu/templates/tests/test-connection.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.testConnection" . }}

--- a/charts/marimo-pytorch-gpu/values.schema.json
+++ b/charts/marimo-pytorch-gpu/values.schema.json
@@ -1,0 +1,1143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "service": {
+      "title": "Service",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Docker image",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "title": "Pull image from registry",
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "title": "Name of the service's Docker image",
+              "type": "string",
+              "default": "pacordonnier/marimo-pytorch:py3.13.12-gpu",
+              "listEnum": [
+                "pacordonnier/marimo-pytorch:py3.13.12-gpu",
+                "pacordonnier/marimo-pytorch:py3.12.13-gpu"
+              ],
+              "render": "list",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              }
+            },
+            "custom": {
+              "title": "Custom image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Use a custom image instead",
+                  "type": "boolean",
+                  "default": false,
+                  "x-onyxia": {
+                    "overwriteSchemaWith": "ide/customImage.json"
+                  }
+                },
+                "version": {
+                  "title": "Name of the custom image",
+                  "type": "string",
+                  "default": "pacordonnier/marimo-pytorch:py3.13.12-gpu",
+                  "hidden": {
+                    "value": false,
+                    "path": "enabled",
+                    "isPathRelative": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources (CPU/RAM)",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/resources-gpu.json"
+      },
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Guaranteed CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuRequest",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Guaranteed memory allocation",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryRequest",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Maximum CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuLimit",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Maximum memory allocation",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryLimit",
+                "useRegionSliderConfig": "memory"
+              }
+            },
+            "nvidia.com/gpu": {
+              "description": "GPU to allocate to this instance. This is also requested",
+              "type": "string",
+              "default": "1",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 3,
+              "sliderStep": 1,
+              "sliderUnit": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.gpu",
+                "useRegionSliderConfig": "gpu"
+              }
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/persistence.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Create a persistent volume",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "title": "Persistent volume size",
+          "type": "string",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "overwriteDefaultWith": "region.resources.disk",
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "init": {
+      "title": "Initialization scripts",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/init.json"
+      },
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "regionInitCheckSum": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptCheckSum}}"
+          }
+        },
+        "personalInit": {
+          "title": "Use a custom script (URL)",
+          "type": "string",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "title": "Arguments for the custom script",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "extraEnvVars": {
+      "title": "Environment variables available within your service",
+      "type": "array",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/extraenv.json"
+      },
+      "items": {
+        "title": "",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "VAR_NAME",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "title": "Kubernetes permissions",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/role.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Kubernetes access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "role": {
+          "title": "Kubernetes role",
+          "description": "access is restricted to your own namespace",
+          "type": "string",
+          "default": "view",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "listEnum": [
+            "view",
+            "edit",
+            "admin"
+          ],
+          "render": "list"
+        }
+      }
+    },
+    "openshiftSCC": {
+      "description": "configuration for openshift compatibility",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/openshiftSCC.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "enable rolebinding with openshift scc",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.enabled"
+          }
+        },
+        "scc": {
+          "type": "string",
+          "description": "name of scc for rolebinding",
+          "default": "anyuid",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.scc"
+          }
+        }
+      }
+    },
+    "vault": {
+      "title": "Vault access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/vault.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Vault access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "token": {
+          "title": "Vault token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "url": {
+          "title": "Vault server URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "mount": {
+          "title": "Secret engine",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "directory": {
+          "title": "Top-level directory",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secret": {
+          "title": "Path to the secret to load",
+          "description": "The secret will be converted into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "s3": {
+      "title": "S3 object storage",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/s3.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable S3 access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "accessKeyId": {
+          "title": "Access Key ID",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "s3.AWS_ACCESS_KEY_ID"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "endpoint": {
+          "title": "S3 endpoint URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "defaultRegion": {
+          "title": "Default region",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secretAccessKey": {
+          "title": "Secret Access Key",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "sessionToken": {
+          "title": "Session token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "pathStyleAccess": {
+          "title": "Path-style access",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.pathStyleAccess}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "workingDirectoryPath": {
+          "title": "Working directory path",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.workingDirectoryPath}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "git": {
+      "title": "Git access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/git.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable git access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "title": "User name",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "email": {
+          "title": "User email",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "cache": {
+          "title": "Credentials caching duration",
+          "description": "(in seconds)",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "token": {
+          "title": "Personal Access Token",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "repository": {
+          "title": "Project repository",
+          "description": "cloned in service",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "branch": {
+          "title": "Specific branch to use",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "asCodeServerRoot": {
+          "title": "Open the service in the clone folder",
+          "type": "boolean",
+          "default": false,
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "networking": {
+      "title": "Network access",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/networking.json"
+      },
+      "properties": {
+        "user": {
+          "title": "Ports",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable access to your service through specific ports",
+              "type": "boolean",
+              "default": false
+            },
+            "port": {
+              "title": "Port number to expose",
+              "type": "integer",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            },
+            "ports": {
+              "title": "Port numbers to expose",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "uniqueItems": true,
+                "default": 5000
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "title": "Third party services discovery",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "title": "Discover Hive Metastore services",
+          "type": "boolean",
+          "default": true
+        },
+        "mlflow": {
+          "title": "Discover MLflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "metaflow": {
+          "title": "Discover Metaflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "chromadb": {
+          "title": "Discover ChromaDB services",
+          "type": "boolean",
+          "default": true
+        },
+        "milvus": {
+          "title": "Discover Milvus services",
+          "type": "boolean",
+          "default": true
+        },
+        "postgresql": {
+          "title": "Discover PostgreSQL services",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "security": {
+      "title": "Security",
+      "type": "object",
+      "properties": {
+        "password": {
+          "title": "Service password",
+          "type": "string",
+          "default": "changeme",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{service.oneTimePassword}}",
+            "overwriteSchemaWith": "ide/password.json"
+          }
+        },
+        "networkPolicy": {
+          "title": "Network access policy",
+          "type": "object",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "title": "Only allow access from the same namespace",
+              "type": "boolean",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "description": "Array of sources allowed to have network access to your service",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "NodeSelector",
+      "default": {},
+      "x-onyxia": {
+        "overwriteDefaultWith": "region.nodeSelector",
+        "overwriteSchemaWith": "nodeSelector-gpu.json"
+      }
+    },
+    "ingress": {
+      "title": "Ingress Details",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/ingress.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        },
+        "useCertManager": {
+          "type": "boolean",
+          "description": "Whether CertManager should be used to generate a certificate",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.useCertManager"
+          }
+        },
+        "certManagerClusterIssuer": {
+          "type": "string",
+          "description": "certManager cluster issuer",
+          "title": "CertManager Cluster Issuer",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
+          }
+        },
+        "useTlsSecret": {
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tlsSecretName": {
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "repository.json"
+      },
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
+    },
+    "startupProbe": {
+      "description": "Startup probe",
+      "type": "object",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "default": 60
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "default": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "default": 2
+        }
+      },
+      "default": {
+        "failureThreshold": 60,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "timeoutSeconds": 2
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.startupProbe",
+        "overwriteSchemaWith": "ide/startupProbe.json"
+      }
+    },
+    "tolerations": {
+      "description": "Array of tolerations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "userPreferences": {
+      "title": "User Preferences",
+      "type": "object",
+      "properties": {
+        "darkMode": {
+          "type": "boolean",
+          "description": "dark mode is or is not enabled",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.darkMode"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Preferred language",
+          "default": "en",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.lang"
+          }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Continue, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            },
+            "useLegacyCompletionsEndpoint": {
+              "title": "use legacy completions endpoint",
+              "type": "boolean",
+              "default": true,
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
+              }
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "proxy": {
+      "description": "It can be used to inject proxy settings in the services",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "proxy.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Inject proxy settings",
+          "default": false
+        },
+        "httpProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTP.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTPS.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "enterprise local domain that should not take proxy comma separated",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "description": "It can be used to inject certificate authority into the services, if the Helm chart in the catalog allows it you can bind this value to the Helm chart value to add some certificate authorities in the pod.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "certificates.json"
+      },
+      "default": {},
+      "properties": {
+        "cacerts": {
+          "type": "string",
+          "description": "String of concatenated CA certificates. Alternatively a target URL can be provided.",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "pathToCaBundle": {
+          "type": "string",
+          "description": "String path where a bundle is made or injected by third party solution",
+          "default": "/usr/local/share/ca-certificates/",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "Warning message",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/message.json"
+      },
+      "properties": {
+        "fr": {
+          "type": "string",
+          "description": "message \u00e0 ajouter dans les notes",
+          "default": ""
+        },
+        "en": {
+          "type": "string",
+          "description": "message to add in notes",
+          "default": ""
+        }
+      }
+    },
+    "runtimeClassName": {
+      "type": "string",
+      "description": "Runtime Class Name",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/runtimeClassName.json"
+      }
+    }
+  }
+}

--- a/charts/marimo-pytorch-gpu/values.yaml
+++ b/charts/marimo-pytorch-gpu/values.yaml
@@ -1,0 +1,169 @@
+global:
+  suspend: false
+service:
+  initContainer:
+    image: inseefrlab/onyxia-base:latest
+    pullPolicy: IfNotPresent
+  image:
+    version: pacordonnier/marimo-pytorch:py3.13.12-gpu
+    pullPolicy: IfNotPresent
+    custom:
+      enabled: false
+      version: pacordonnier/marimo-pytorch:py3.13.12-gpu
+security:
+  password: changeme
+  networkPolicy:
+    enabled: false
+    from: []
+  allowlist:
+    enabled: false
+    ip: 0.0.0.0/0
+init:
+  standardInitPath: /opt/onyxia-init.sh
+  regionInit: ''
+  regionInitCheckSum: ''
+  personalInit: ''
+  personalInitArgs: ''
+extraEnvVars: []
+s3:
+  enabled: false
+  secretName: ''
+  accessKeyId: ''
+  endpoint: ''
+  defaultRegion: ''
+  secretAccessKey: ''
+  sessionToken: ''
+  pathStyleAccess: false
+  workingDirectoryPath: ''
+vault:
+  enabled: false
+  secretName: ''
+  token: ''
+  url: ''
+  mount: ''
+  secret: ''
+  directory: ''
+git:
+  enabled: true
+  secretName: ''
+  name: ''
+  email: ''
+  cache: ''
+  branch: ''
+  asCodeServerRoot: false
+repository:
+  configMapName: ''
+  pipRepository: ''
+  condaRepository: ''
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+  chromadb: true
+  milvus: true
+  postgresql: true
+hive:
+  secretName: ''
+mlflow:
+  secretName: ''
+metaflow:
+  secretName: ''
+chromadb:
+  secretName: ''
+milvus:
+  secretName: ''
+coresite:
+  secretName: ''
+postgresql:
+  secretName: ''
+replicaCount: 1
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ''
+environment:
+  user: onyxia
+  group: users
+kubernetes:
+  enabled: true
+  role: view
+podAnnotations: {}
+podSecurityContext:
+  fsGroup: 100
+securityContext: {}
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    port: 2718
+  user:
+    enabled: false
+    port: 5000
+    ports: []
+ingress:
+  enabled: false
+  tls: true
+  ingressClassName: ''
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  path: /
+  userPath: /
+  useCertManager: false
+  certManagerClusterIssuer: ''
+  useTlsSecret: false
+  tlsSecretName: ''
+route:
+  enabled: false
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  tls:
+    termination: edge
+  wildcardPolicy: None
+resources: {}
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 10Gi
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+nodeSelector: {}
+tolerations: []
+affinity: {}
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+userPreferences:
+  darkMode: false
+  language: en
+  aiAssistant:
+    enabled: false
+    model: ''
+    provider: ''
+    apiBase: ''
+    apiKey: ''
+    secretName: ''
+    useLegacyCompletionsEndpoint: false
+openshiftSCC:
+  enabled: false
+  scc: ''
+proxy:
+  enabled: false
+  noProxy: ''
+  httpProxy: ''
+  httpsProxy: ''
+certificates: {}
+message:
+  fr: ''
+  en: ''
+runtimeClassName: ''

--- a/charts/marimo-pytorch/.helmignore
+++ b/charts/marimo-pytorch/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/marimo-pytorch/Chart.yaml
+++ b/charts/marimo-pytorch/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: marimo-pytorch
+description: Marimo reactive Python notebook with Python and the deep-learning framework PyTorch.
+icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/marimo.png
+keywords:
+- Marimo
+- Python
+home: https://marimo.io/
+sources:
+- https://github.com/InseeFrLab/images-datascience
+- https://github.com/InseeFrLab/helm-charts-interactive-services
+type: application
+version: 0.0.1
+dependencies:
+- name: library-chart
+  version: 2.0.4
+  repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/marimo-pytorch/templates/NOTES.txt
+++ b/charts/marimo-pytorch/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}

--- a/charts/marimo-pytorch/templates/NOTES.txt
+++ b/charts/marimo-pytorch/templates/NOTES.txt
@@ -1,1 +1,1 @@
-{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}
+{{- template "library-chart.notes" (dict "serviceName" "Marimo (Python)" "context" $) -}}

--- a/charts/marimo-pytorch/templates/configmap-repository.yaml
+++ b/charts/marimo-pytorch/templates/configmap-repository.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapRepository" . }}

--- a/charts/marimo-pytorch/templates/ingress-user.yaml
+++ b/charts/marimo-pytorch/templates/ingress-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressUser" . }}

--- a/charts/marimo-pytorch/templates/ingress.yaml
+++ b/charts/marimo-pytorch/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingress" . }}

--- a/charts/marimo-pytorch/templates/networkpolicy-ingress.yaml
+++ b/charts/marimo-pytorch/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicyIngress" . }}

--- a/charts/marimo-pytorch/templates/networkpolicy.yaml
+++ b/charts/marimo-pytorch/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/marimo-pytorch/templates/pvc.yaml
+++ b/charts/marimo-pytorch/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/marimo-pytorch/templates/role-binding-scc.yaml
+++ b/charts/marimo-pytorch/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/marimo-pytorch/templates/role-binding.yaml
+++ b/charts/marimo-pytorch/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/marimo-pytorch/templates/route-user.yaml
+++ b/charts/marimo-pytorch/templates/route-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeUser" . }}

--- a/charts/marimo-pytorch/templates/route.yaml
+++ b/charts/marimo-pytorch/templates/route.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.route" . }}

--- a/charts/marimo-pytorch/templates/secret-assistant.yaml
+++ b/charts/marimo-pytorch/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistant" . }}

--- a/charts/marimo-pytorch/templates/secret-cacerts.yaml
+++ b/charts/marimo-pytorch/templates/secret-cacerts.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCacerts" . }}

--- a/charts/marimo-pytorch/templates/secret-chromadb.yaml
+++ b/charts/marimo-pytorch/templates/secret-chromadb.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretChromaDB" . }}

--- a/charts/marimo-pytorch/templates/secret-extraenv.yaml
+++ b/charts/marimo-pytorch/templates/secret-extraenv.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretExtraEnv" . }}

--- a/charts/marimo-pytorch/templates/secret-git.yaml
+++ b/charts/marimo-pytorch/templates/secret-git.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretGit" . }}

--- a/charts/marimo-pytorch/templates/secret-hive.yaml
+++ b/charts/marimo-pytorch/templates/secret-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretHive" . }}

--- a/charts/marimo-pytorch/templates/secret-metaflow.yaml
+++ b/charts/marimo-pytorch/templates/secret-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMetaflow" . }}

--- a/charts/marimo-pytorch/templates/secret-milvus.yaml
+++ b/charts/marimo-pytorch/templates/secret-milvus.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMilvus" . }}

--- a/charts/marimo-pytorch/templates/secret-mlflow.yaml
+++ b/charts/marimo-pytorch/templates/secret-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMLFlow" . }}

--- a/charts/marimo-pytorch/templates/secret-postgresql.yaml
+++ b/charts/marimo-pytorch/templates/secret-postgresql.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretPostgreSQL" . }}

--- a/charts/marimo-pytorch/templates/secret-proxy.yaml
+++ b/charts/marimo-pytorch/templates/secret-proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretProxy" . }}

--- a/charts/marimo-pytorch/templates/secret-s3.yaml
+++ b/charts/marimo-pytorch/templates/secret-s3.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretS3" . }}

--- a/charts/marimo-pytorch/templates/secret-token.yaml
+++ b/charts/marimo-pytorch/templates/secret-token.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretToken" . }}

--- a/charts/marimo-pytorch/templates/secret-vault.yaml
+++ b/charts/marimo-pytorch/templates/secret-vault.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretVault" . }}

--- a/charts/marimo-pytorch/templates/service.yaml
+++ b/charts/marimo-pytorch/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/marimo-pytorch/templates/serviceaccount.yaml
+++ b/charts/marimo-pytorch/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/marimo-pytorch/templates/statefulset.yaml
+++ b/charts/marimo-pytorch/templates/statefulset.yaml
@@ -1,0 +1,316 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if not (.Values.autoscaling).enabled }}
+  {{- if (.Values.global).suspend }}
+  replicas: 0
+  {{- else }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (.Values.git).enabled }}
+        checksum/git: {{ include (print $.Template.BasePath "/secret-git.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.s3).enabled }}
+        checksum/s3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.vault).enabled }}
+        checksum/vault: {{ include (print $.Template.BasePath "/secret-vault.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretHive" .))) }}
+        checksum/hive: {{ include (print $.Template.BasePath "/secret-hive.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMetaflow" .))) }}
+        checksum/metaflow: {{ include (print $.Template.BasePath "/secret-metaflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/secret-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+        checksum/chromadb: {{ include (print $.Template.BasePath "/secret-chromadb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+        checksum/milvus: {{ include (print $.Template.BasePath "/secret-milvus.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+        checksum/postgresql: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "library-chart.repository.enabled"  .) }}
+        checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        checksum/cacerts: {{ .Values.certificates.cacerts | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.runtimeClassName -}}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
+      volumes:
+        - name: config-files
+          emptyDir: {}
+        - name: home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        {{- if (.Values.proxy).enabled }}
+        - name: secret-proxy
+          secret:
+            secretName: {{ include "library-chart.secretNameProxy" . }}
+        {{- end }}
+        {{- if .Values.discovery.hive }}
+        - name: secret-hive
+          secret:
+            secretName: {{ include "library-chart.secretNameHive" . }}
+        {{- end }}
+        {{- if .Values.discovery.metaflow }}
+        - name: secret-metaflow
+          secret:
+            secretName: {{ include "library-chart.secretNameMetaflow" . }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        - name: cacerts
+          secret:
+            secretName: {{ include "library-chart.secretNameCacerts" . }}
+        {{- end }}
+        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistant" . }}
+        {{- end }}
+        - name: token
+          secret:
+            secretName: {{ include "library-chart.secretNameToken" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: make-secrets-writable
+          image: {{ .Values.service.initContainer.image }}
+          imagePullPolicy: {{ .Values.service.initContainer.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              echo 'initContainer make-secrets-writable is started';
+              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              mkdir /dest/continue
+              cp /src/continue/config.yaml /dest/continue/config.yaml
+              {{- end }}
+              {{- if .Values.discovery.hive }}
+              mkdir /dest/hive;
+              cp /src/hive/hive-site.xml /dest/hive/hive-site.xml;
+              {{- end }}
+              {{- if .Values.discovery.metaflow }}
+              mkdir /dest/metaflow;
+              cp /src/metaflow/config.json /dest/metaflow/config.json;
+              {{- end }}
+              {{- if and .Values.certificates .Values.certificates.cacerts }}
+              mkdir /dest/cacerts;
+              {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
+              curl -s $(cat /cacerts/ca-certs.url) -o /tmp/ca.pem
+              {{- else }}
+              cp /cacerts/ca.pem /tmp/ca.pem
+              {{- end }}
+              awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
+              {{- end }}
+          volumeMounts:
+            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            - name: secret-assistant
+              mountPath: /src/continue
+            {{- end }}
+            - name: config-files
+              mountPath: /dest
+            {{- if and .Values.certificates .Values.certificates.cacerts }}
+            - name: cacerts
+              mountPath: /cacerts
+            {{- end }}
+            {{- if .Values.discovery.hive }}
+            - name: secret-hive
+              mountPath: /src/hive
+            {{- end }}
+            {{- if .Values.discovery.metaflow }}
+            - name : secret-metaflow
+              mountPath: /src/metaflow
+            {{- end }}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.service.image.custom.enabled }}
+          image: "{{ .Values.service.image.custom.version }}"
+          {{- else }}
+          image: "{{ .Values.service.image.version }}"
+          {{- end }}
+          command: ["/bin/sh","-c"]
+          {{- if .Values.git.asCodeServerRoot }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
+          {{- else }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
+          {{- end }}
+          imagePullPolicy: {{ .Values.service.image.pullPolicy }}
+          env:
+            {{- if .Values.init.regionInit }}
+            - name: REGION_INIT_SCRIPT
+              value: {{ .Values.init.regionInit }}
+            {{- end }}
+            {{- if .Values.init.regionInitCheckSum }}
+            - name: REGION_INIT_SCRIPT_CHECKSUM
+              value: {{ .Values.init.regionInitCheckSum }}
+            {{- end }}
+            {{- if .Values.init.personalInit }}
+            - name: PERSONAL_INIT_SCRIPT
+              value: {{ .Values.init.personalInit }}
+            {{- end }}
+            {{- if .Values.init.personalInitArgs }}
+            - name: PERSONAL_INIT_ARGS
+              value: {{ .Values.init.personalInitArgs }}
+            {{- end }}
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: ROOT_PROJECT_DIRECTORY
+              value: /home/{{ .Values.environment.user }}/work
+            {{- if .Values.userPreferences.darkMode }}
+            - name: DARK_MODE
+              value: "true"
+            {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
+          envFrom:
+            - secretRef:
+                name : {{ include "library-chart.secretNameToken" . }}
+            {{- if (.Values.git).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameGit" . }}
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameS3" . }}
+            {{- end }}
+            {{- if (.Values.vault).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameVault" . }}
+            {{- end }}
+            {{- if (.Values.proxy).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameProxy" . }}
+            {{- end }}
+            {{- if (include "library-chart.repository.enabled" .) }}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameRepository" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMLFlow" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNamePostgreSQL" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameChromaDB" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMilvus" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameExtraEnv" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 2
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          {{- if hasKey .Values "startupProbe" }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+            - name: token
+              mountPath: /home/{{ .Values.environment.user }}/.token
+              readOnly: true
+            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.continue
+              subPath: continue
+              name: config-files
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: config-files
+              mountPath: /usr/local/lib/hive/conf/hive-site.xml
+              subPath: hive/hive-site.xml
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.metaflowconfig
+              subPath: metaflow
+            {{- end }}
+            {{- if (.Values.certificates).pathToCaBundle }}
+            - name: config-files
+              mountPath: {{ .Values.certificates.pathToCaBundle }}
+              subPath: cacerts
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/marimo-pytorch/templates/tests/test-connection.yaml
+++ b/charts/marimo-pytorch/templates/tests/test-connection.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.testConnection" . }}

--- a/charts/marimo-pytorch/values.schema.json
+++ b/charts/marimo-pytorch/values.schema.json
@@ -1,0 +1,1133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "service": {
+      "title": "Service",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Docker image",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "title": "Pull image from registry",
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "title": "Name of the service's Docker image",
+              "type": "string",
+              "default": "pacordonnier/marimo-pytorch:py3.13.12",
+              "listEnum": [
+                "pacordonnier/marimo-pytorch:py3.13.12",
+                "pacordonnier/marimo-pytorch:py3.12.13"
+              ],
+              "render": "list",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              }
+            },
+            "custom": {
+              "title": "Custom image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Use a custom image instead",
+                  "type": "boolean",
+                  "default": false,
+                  "x-onyxia": {
+                    "overwriteSchemaWith": "ide/customImage.json"
+                  }
+                },
+                "version": {
+                  "title": "Name of the custom image",
+                  "type": "string",
+                  "default": "pacordonnier/marimo-pytorch:py3.13.12",
+                  "hidden": {
+                    "value": false,
+                    "path": "enabled",
+                    "isPathRelative": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources (CPU/RAM)",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/resources.json"
+      },
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Guaranteed CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuRequest",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Guaranteed memory allocation",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryRequest",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Maximum CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuLimit",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Maximum memory allocation",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryLimit",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/persistence.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Create a persistent volume",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "title": "Persistent volume size",
+          "type": "string",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "overwriteDefaultWith": "region.resources.disk",
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "init": {
+      "title": "Initialization scripts",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/init.json"
+      },
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "regionInitCheckSum": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptCheckSum}}"
+          }
+        },
+        "personalInit": {
+          "title": "Use a custom script (URL)",
+          "type": "string",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "title": "Arguments for the custom script",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "extraEnvVars": {
+      "title": "Environment variables available within your service",
+      "type": "array",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/extraenv.json"
+      },
+      "items": {
+        "title": "",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "VAR_NAME",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "title": "Kubernetes permissions",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/role.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Kubernetes access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "role": {
+          "title": "Kubernetes role",
+          "description": "access is restricted to your own namespace",
+          "type": "string",
+          "default": "view",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "listEnum": [
+            "view",
+            "edit",
+            "admin"
+          ],
+          "render": "list"
+        }
+      }
+    },
+    "openshiftSCC": {
+      "description": "configuration for openshift compatibility",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/openshiftSCC.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "enable rolebinding with openshift scc",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.enabled"
+          }
+        },
+        "scc": {
+          "type": "string",
+          "description": "name of scc for rolebinding",
+          "default": "anyuid",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.scc"
+          }
+        }
+      }
+    },
+    "vault": {
+      "title": "Vault access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/vault.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Vault access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "token": {
+          "title": "Vault token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "url": {
+          "title": "Vault server URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "mount": {
+          "title": "Secret engine",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "directory": {
+          "title": "Top-level directory",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secret": {
+          "title": "Path to the secret to load",
+          "description": "The secret will be converted into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "s3": {
+      "title": "S3 object storage",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/s3.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable S3 access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "accessKeyId": {
+          "title": "Access Key ID",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "s3.AWS_ACCESS_KEY_ID"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "endpoint": {
+          "title": "S3 endpoint URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "defaultRegion": {
+          "title": "Default region",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secretAccessKey": {
+          "title": "Secret Access Key",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "sessionToken": {
+          "title": "Session token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "pathStyleAccess": {
+          "title": "Path-style access",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.pathStyleAccess}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "workingDirectoryPath": {
+          "title": "Working directory path",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.workingDirectoryPath}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "git": {
+      "title": "Git access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/git.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable git access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "title": "User name",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "email": {
+          "title": "User email",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "cache": {
+          "title": "Credentials caching duration",
+          "description": "(in seconds)",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "token": {
+          "title": "Personal Access Token",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "repository": {
+          "title": "Project repository",
+          "description": "cloned in service",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "branch": {
+          "title": "Specific branch to use",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "asCodeServerRoot": {
+          "title": "Open the service in the clone folder",
+          "type": "boolean",
+          "default": false,
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "networking": {
+      "title": "Network access",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/networking.json"
+      },
+      "properties": {
+        "user": {
+          "title": "Ports",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable access to your service through specific ports",
+              "type": "boolean",
+              "default": false
+            },
+            "port": {
+              "title": "Port number to expose",
+              "type": "integer",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            },
+            "ports": {
+              "title": "Port numbers to expose",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "uniqueItems": true,
+                "default": 5000
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "title": "Third party services discovery",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "title": "Discover Hive Metastore services",
+          "type": "boolean",
+          "default": true
+        },
+        "mlflow": {
+          "title": "Discover MLflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "metaflow": {
+          "title": "Discover Metaflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "chromadb": {
+          "title": "Discover ChromaDB services",
+          "type": "boolean",
+          "default": true
+        },
+        "milvus": {
+          "title": "Discover Milvus services",
+          "type": "boolean",
+          "default": true
+        },
+        "postgresql": {
+          "title": "Discover PostgreSQL services",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "security": {
+      "title": "Security",
+      "type": "object",
+      "properties": {
+        "password": {
+          "title": "Service password",
+          "type": "string",
+          "default": "changeme",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{service.oneTimePassword}}",
+            "overwriteSchemaWith": "ide/password.json"
+          }
+        },
+        "networkPolicy": {
+          "title": "Network access policy",
+          "type": "object",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "title": "Only allow access from the same namespace",
+              "type": "boolean",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "description": "Array of sources allowed to have network access to your service",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "title": "Node selector",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      },
+      "x-onyxia": {
+        "hidden": false,
+        "overwriteDefaultWith": "region.nodeSelector",
+        "overwriteSchemaWith": "nodeSelector.json"
+      }
+    },
+    "ingress": {
+      "title": "Ingress Details",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/ingress.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        },
+        "useCertManager": {
+          "type": "boolean",
+          "description": "Whether CertManager should be used to generate a certificate",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.useCertManager"
+          }
+        },
+        "certManagerClusterIssuer": {
+          "type": "string",
+          "description": "certManager cluster issuer",
+          "title": "CertManager Cluster Issuer",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
+          }
+        },
+        "useTlsSecret": {
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tlsSecretName": {
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "repository.json"
+      },
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
+    },
+    "startupProbe": {
+      "description": "Startup probe",
+      "type": "object",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "default": 60
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "default": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "default": 2
+        }
+      },
+      "default": {
+        "failureThreshold": 60,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "timeoutSeconds": 2
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.startupProbe",
+        "overwriteSchemaWith": "ide/startupProbe.json"
+      }
+    },
+    "tolerations": {
+      "description": "Array of tolerations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "userPreferences": {
+      "title": "User Preferences",
+      "type": "object",
+      "properties": {
+        "darkMode": {
+          "type": "boolean",
+          "description": "dark mode is or is not enabled",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.darkMode"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Preferred language",
+          "default": "en",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.lang"
+          }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Continue, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            },
+            "useLegacyCompletionsEndpoint": {
+              "title": "use legacy completions endpoint",
+              "type": "boolean",
+              "default": true,
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
+              }
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "proxy": {
+      "description": "It can be used to inject proxy settings in the services",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "proxy.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Inject proxy settings",
+          "default": false
+        },
+        "httpProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTP.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTPS.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "enterprise local domain that should not take proxy comma separated",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "description": "It can be used to inject certificate authority into the services, if the Helm chart in the catalog allows it you can bind this value to the Helm chart value to add some certificate authorities in the pod.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "certificates.json"
+      },
+      "default": {},
+      "properties": {
+        "cacerts": {
+          "type": "string",
+          "description": "String of concatenated CA certificates. Alternatively a target URL can be provided.",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "pathToCaBundle": {
+          "type": "string",
+          "description": "String path where a bundle is made or injected by third party solution",
+          "default": "/usr/local/share/ca-certificates/",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "Warning message",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/message.json"
+      },
+      "properties": {
+        "fr": {
+          "type": "string",
+          "description": "message \u00e0 ajouter dans les notes",
+          "default": ""
+        },
+        "en": {
+          "type": "string",
+          "description": "message to add in notes",
+          "default": ""
+        }
+      }
+    },
+    "runtimeClassName": {
+      "type": "string",
+      "description": "Runtime Class Name",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/runtimeClassName.json"
+      }
+    }
+  }
+}

--- a/charts/marimo-pytorch/values.yaml
+++ b/charts/marimo-pytorch/values.yaml
@@ -1,0 +1,169 @@
+global:
+  suspend: false
+service:
+  initContainer:
+    image: inseefrlab/onyxia-base:latest
+    pullPolicy: IfNotPresent
+  image:
+    version: pacordonnier/marimo-pytorch:py3.13.12
+    pullPolicy: IfNotPresent
+    custom:
+      enabled: false
+      version: pacordonnier/marimo-pytorch:py3.13.12
+security:
+  password: changeme
+  networkPolicy:
+    enabled: false
+    from: []
+  allowlist:
+    enabled: false
+    ip: 0.0.0.0/0
+init:
+  standardInitPath: /opt/onyxia-init.sh
+  regionInit: ''
+  regionInitCheckSum: ''
+  personalInit: ''
+  personalInitArgs: ''
+extraEnvVars: []
+s3:
+  enabled: false
+  secretName: ''
+  accessKeyId: ''
+  endpoint: ''
+  defaultRegion: ''
+  secretAccessKey: ''
+  sessionToken: ''
+  pathStyleAccess: false
+  workingDirectoryPath: ''
+vault:
+  enabled: false
+  secretName: ''
+  token: ''
+  url: ''
+  mount: ''
+  secret: ''
+  directory: ''
+git:
+  enabled: true
+  secretName: ''
+  name: ''
+  email: ''
+  cache: ''
+  branch: ''
+  asCodeServerRoot: false
+repository:
+  configMapName: ''
+  pipRepository: ''
+  condaRepository: ''
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+  chromadb: true
+  milvus: true
+  postgresql: true
+hive:
+  secretName: ''
+mlflow:
+  secretName: ''
+metaflow:
+  secretName: ''
+chromadb:
+  secretName: ''
+milvus:
+  secretName: ''
+coresite:
+  secretName: ''
+postgresql:
+  secretName: ''
+replicaCount: 1
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ''
+environment:
+  user: onyxia
+  group: users
+kubernetes:
+  enabled: true
+  role: view
+podAnnotations: {}
+podSecurityContext:
+  fsGroup: 100
+securityContext: {}
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    port: 2718
+  user:
+    enabled: false
+    port: 5000
+    ports: []
+ingress:
+  enabled: false
+  tls: true
+  ingressClassName: ''
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  path: /
+  userPath: /
+  useCertManager: false
+  certManagerClusterIssuer: ''
+  useTlsSecret: false
+  tlsSecretName: ''
+route:
+  enabled: false
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  tls:
+    termination: edge
+  wildcardPolicy: None
+resources: {}
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 10Gi
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+nodeSelector: {}
+tolerations: []
+affinity: {}
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+userPreferences:
+  darkMode: false
+  language: en
+  aiAssistant:
+    enabled: false
+    model: ''
+    provider: ''
+    apiBase: ''
+    apiKey: ''
+    secretName: ''
+    useLegacyCompletionsEndpoint: false
+openshiftSCC:
+  enabled: false
+  scc: ''
+proxy:
+  enabled: false
+  noProxy: ''
+  httpProxy: ''
+  httpsProxy: ''
+certificates: {}
+message:
+  fr: ''
+  en: ''
+runtimeClassName: ''

--- a/charts/marimo-tensorflow-gpu/.helmignore
+++ b/charts/marimo-tensorflow-gpu/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/marimo-tensorflow-gpu/Chart.yaml
+++ b/charts/marimo-tensorflow-gpu/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: marimo-tensorflow-gpu
+description: Marimo reactive Python notebook with Python and the deep-learning framework TensorFlow,
+  with GPU support.
+icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/marimo.png
+keywords:
+- Marimo
+- Python
+home: https://marimo.io/
+sources:
+- https://github.com/InseeFrLab/images-datascience
+- https://github.com/InseeFrLab/helm-charts-interactive-services
+type: application
+version: 0.0.1
+dependencies:
+- name: library-chart
+  version: 2.0.4
+  repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/marimo-tensorflow-gpu/templates/NOTES.txt
+++ b/charts/marimo-tensorflow-gpu/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}

--- a/charts/marimo-tensorflow-gpu/templates/NOTES.txt
+++ b/charts/marimo-tensorflow-gpu/templates/NOTES.txt
@@ -1,1 +1,1 @@
-{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}
+{{- template "library-chart.notes" (dict "serviceName" "Marimo (Python)" "context" $) -}}

--- a/charts/marimo-tensorflow-gpu/templates/configmap-repository.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/configmap-repository.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapRepository" . }}

--- a/charts/marimo-tensorflow-gpu/templates/ingress-user.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/ingress-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressUser" . }}

--- a/charts/marimo-tensorflow-gpu/templates/ingress.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingress" . }}

--- a/charts/marimo-tensorflow-gpu/templates/networkpolicy-ingress.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicyIngress" . }}

--- a/charts/marimo-tensorflow-gpu/templates/networkpolicy.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/marimo-tensorflow-gpu/templates/pvc.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/marimo-tensorflow-gpu/templates/role-binding-scc.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/marimo-tensorflow-gpu/templates/role-binding.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/marimo-tensorflow-gpu/templates/route-user.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/route-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeUser" . }}

--- a/charts/marimo-tensorflow-gpu/templates/route.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/route.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.route" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-assistant.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistant" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-cacerts.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-cacerts.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCacerts" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-chromadb.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-chromadb.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretChromaDB" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-extraenv.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-extraenv.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretExtraEnv" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-git.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-git.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretGit" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-hive.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretHive" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-metaflow.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMetaflow" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-milvus.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-milvus.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMilvus" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-mlflow.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMLFlow" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-postgresql.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-postgresql.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretPostgreSQL" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-proxy.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretProxy" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-s3.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-s3.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretS3" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-token.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-token.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretToken" . }}

--- a/charts/marimo-tensorflow-gpu/templates/secret-vault.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/secret-vault.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretVault" . }}

--- a/charts/marimo-tensorflow-gpu/templates/service.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/marimo-tensorflow-gpu/templates/serviceaccount.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/marimo-tensorflow-gpu/templates/statefulset.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/statefulset.yaml
@@ -1,0 +1,316 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if not (.Values.autoscaling).enabled }}
+  {{- if (.Values.global).suspend }}
+  replicas: 0
+  {{- else }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (.Values.git).enabled }}
+        checksum/git: {{ include (print $.Template.BasePath "/secret-git.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.s3).enabled }}
+        checksum/s3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.vault).enabled }}
+        checksum/vault: {{ include (print $.Template.BasePath "/secret-vault.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretHive" .))) }}
+        checksum/hive: {{ include (print $.Template.BasePath "/secret-hive.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMetaflow" .))) }}
+        checksum/metaflow: {{ include (print $.Template.BasePath "/secret-metaflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/secret-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+        checksum/chromadb: {{ include (print $.Template.BasePath "/secret-chromadb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+        checksum/milvus: {{ include (print $.Template.BasePath "/secret-milvus.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+        checksum/postgresql: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "library-chart.repository.enabled"  .) }}
+        checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        checksum/cacerts: {{ .Values.certificates.cacerts | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.runtimeClassName -}}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
+      volumes:
+        - name: config-files
+          emptyDir: {}
+        - name: home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        {{- if (.Values.proxy).enabled }}
+        - name: secret-proxy
+          secret:
+            secretName: {{ include "library-chart.secretNameProxy" . }}
+        {{- end }}
+        {{- if .Values.discovery.hive }}
+        - name: secret-hive
+          secret:
+            secretName: {{ include "library-chart.secretNameHive" . }}
+        {{- end }}
+        {{- if .Values.discovery.metaflow }}
+        - name: secret-metaflow
+          secret:
+            secretName: {{ include "library-chart.secretNameMetaflow" . }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        - name: cacerts
+          secret:
+            secretName: {{ include "library-chart.secretNameCacerts" . }}
+        {{- end }}
+        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistant" . }}
+        {{- end }}
+        - name: token
+          secret:
+            secretName: {{ include "library-chart.secretNameToken" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: make-secrets-writable
+          image: {{ .Values.service.initContainer.image }}
+          imagePullPolicy: {{ .Values.service.initContainer.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              echo 'initContainer make-secrets-writable is started';
+              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              mkdir /dest/continue
+              cp /src/continue/config.yaml /dest/continue/config.yaml
+              {{- end }}
+              {{- if .Values.discovery.hive }}
+              mkdir /dest/hive;
+              cp /src/hive/hive-site.xml /dest/hive/hive-site.xml;
+              {{- end }}
+              {{- if .Values.discovery.metaflow }}
+              mkdir /dest/metaflow;
+              cp /src/metaflow/config.json /dest/metaflow/config.json;
+              {{- end }}
+              {{- if and .Values.certificates .Values.certificates.cacerts }}
+              mkdir /dest/cacerts;
+              {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
+              curl -s $(cat /cacerts/ca-certs.url) -o /tmp/ca.pem
+              {{- else }}
+              cp /cacerts/ca.pem /tmp/ca.pem
+              {{- end }}
+              awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
+              {{- end }}
+          volumeMounts:
+            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            - name: secret-assistant
+              mountPath: /src/continue
+            {{- end }}
+            - name: config-files
+              mountPath: /dest
+            {{- if and .Values.certificates .Values.certificates.cacerts }}
+            - name: cacerts
+              mountPath: /cacerts
+            {{- end }}
+            {{- if .Values.discovery.hive }}
+            - name: secret-hive
+              mountPath: /src/hive
+            {{- end }}
+            {{- if .Values.discovery.metaflow }}
+            - name : secret-metaflow
+              mountPath: /src/metaflow
+            {{- end }}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.service.image.custom.enabled }}
+          image: "{{ .Values.service.image.custom.version }}"
+          {{- else }}
+          image: "{{ .Values.service.image.version }}"
+          {{- end }}
+          command: ["/bin/sh","-c"]
+          {{- if .Values.git.asCodeServerRoot }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
+          {{- else }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
+          {{- end }}
+          imagePullPolicy: {{ .Values.service.image.pullPolicy }}
+          env:
+            {{- if .Values.init.regionInit }}
+            - name: REGION_INIT_SCRIPT
+              value: {{ .Values.init.regionInit }}
+            {{- end }}
+            {{- if .Values.init.regionInitCheckSum }}
+            - name: REGION_INIT_SCRIPT_CHECKSUM
+              value: {{ .Values.init.regionInitCheckSum }}
+            {{- end }}
+            {{- if .Values.init.personalInit }}
+            - name: PERSONAL_INIT_SCRIPT
+              value: {{ .Values.init.personalInit }}
+            {{- end }}
+            {{- if .Values.init.personalInitArgs }}
+            - name: PERSONAL_INIT_ARGS
+              value: {{ .Values.init.personalInitArgs }}
+            {{- end }}
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: ROOT_PROJECT_DIRECTORY
+              value: /home/{{ .Values.environment.user }}/work
+            {{- if .Values.userPreferences.darkMode }}
+            - name: DARK_MODE
+              value: "true"
+            {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
+          envFrom:
+            - secretRef:
+                name : {{ include "library-chart.secretNameToken" . }}
+            {{- if (.Values.git).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameGit" . }}
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameS3" . }}
+            {{- end }}
+            {{- if (.Values.vault).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameVault" . }}
+            {{- end }}
+            {{- if (.Values.proxy).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameProxy" . }}
+            {{- end }}
+            {{- if (include "library-chart.repository.enabled" .) }}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameRepository" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMLFlow" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNamePostgreSQL" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameChromaDB" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMilvus" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameExtraEnv" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 2
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          {{- if hasKey .Values "startupProbe" }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+            - name: token
+              mountPath: /home/{{ .Values.environment.user }}/.token
+              readOnly: true
+            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.continue
+              subPath: continue
+              name: config-files
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: config-files
+              mountPath: /usr/local/lib/hive/conf/hive-site.xml
+              subPath: hive/hive-site.xml
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.metaflowconfig
+              subPath: metaflow
+            {{- end }}
+            {{- if (.Values.certificates).pathToCaBundle }}
+            - name: config-files
+              mountPath: {{ .Values.certificates.pathToCaBundle }}
+              subPath: cacerts
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/marimo-tensorflow-gpu/templates/tests/test-connection.yaml
+++ b/charts/marimo-tensorflow-gpu/templates/tests/test-connection.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.testConnection" . }}

--- a/charts/marimo-tensorflow-gpu/values.schema.json
+++ b/charts/marimo-tensorflow-gpu/values.schema.json
@@ -1,0 +1,1143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "service": {
+      "title": "Service",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Docker image",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "title": "Pull image from registry",
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "title": "Name of the service's Docker image",
+              "type": "string",
+              "default": "pacordonnier/marimo-tensorflow:py3.13.12-gpu",
+              "listEnum": [
+                "pacordonnier/marimo-tensorflow:py3.13.12-gpu",
+                "pacordonnier/marimo-tensorflow:py3.12.13-gpu"
+              ],
+              "render": "list",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              }
+            },
+            "custom": {
+              "title": "Custom image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Use a custom image instead",
+                  "type": "boolean",
+                  "default": false,
+                  "x-onyxia": {
+                    "overwriteSchemaWith": "ide/customImage.json"
+                  }
+                },
+                "version": {
+                  "title": "Name of the custom image",
+                  "type": "string",
+                  "default": "pacordonnier/marimo-tensorflow:py3.13.12-gpu",
+                  "hidden": {
+                    "value": false,
+                    "path": "enabled",
+                    "isPathRelative": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources (CPU/RAM)",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/resources-gpu.json"
+      },
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Guaranteed CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuRequest",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Guaranteed memory allocation",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryRequest",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Maximum CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuLimit",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Maximum memory allocation",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryLimit",
+                "useRegionSliderConfig": "memory"
+              }
+            },
+            "nvidia.com/gpu": {
+              "description": "GPU to allocate to this instance. This is also requested",
+              "type": "string",
+              "default": "1",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 3,
+              "sliderStep": 1,
+              "sliderUnit": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.gpu",
+                "useRegionSliderConfig": "gpu"
+              }
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/persistence.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Create a persistent volume",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "title": "Persistent volume size",
+          "type": "string",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "overwriteDefaultWith": "region.resources.disk",
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "init": {
+      "title": "Initialization scripts",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/init.json"
+      },
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "regionInitCheckSum": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptCheckSum}}"
+          }
+        },
+        "personalInit": {
+          "title": "Use a custom script (URL)",
+          "type": "string",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "title": "Arguments for the custom script",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "extraEnvVars": {
+      "title": "Environment variables available within your service",
+      "type": "array",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/extraenv.json"
+      },
+      "items": {
+        "title": "",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "VAR_NAME",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "title": "Kubernetes permissions",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/role.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Kubernetes access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "role": {
+          "title": "Kubernetes role",
+          "description": "access is restricted to your own namespace",
+          "type": "string",
+          "default": "view",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "listEnum": [
+            "view",
+            "edit",
+            "admin"
+          ],
+          "render": "list"
+        }
+      }
+    },
+    "openshiftSCC": {
+      "description": "configuration for openshift compatibility",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/openshiftSCC.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "enable rolebinding with openshift scc",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.enabled"
+          }
+        },
+        "scc": {
+          "type": "string",
+          "description": "name of scc for rolebinding",
+          "default": "anyuid",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.scc"
+          }
+        }
+      }
+    },
+    "vault": {
+      "title": "Vault access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/vault.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Vault access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "token": {
+          "title": "Vault token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "url": {
+          "title": "Vault server URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "mount": {
+          "title": "Secret engine",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "directory": {
+          "title": "Top-level directory",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secret": {
+          "title": "Path to the secret to load",
+          "description": "The secret will be converted into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "s3": {
+      "title": "S3 object storage",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/s3.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable S3 access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "accessKeyId": {
+          "title": "Access Key ID",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "s3.AWS_ACCESS_KEY_ID"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "endpoint": {
+          "title": "S3 endpoint URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "defaultRegion": {
+          "title": "Default region",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secretAccessKey": {
+          "title": "Secret Access Key",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "sessionToken": {
+          "title": "Session token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "pathStyleAccess": {
+          "title": "Path-style access",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.pathStyleAccess}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "workingDirectoryPath": {
+          "title": "Working directory path",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.workingDirectoryPath}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "git": {
+      "title": "Git access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/git.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable git access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "title": "User name",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "email": {
+          "title": "User email",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "cache": {
+          "title": "Credentials caching duration",
+          "description": "(in seconds)",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "token": {
+          "title": "Personal Access Token",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "repository": {
+          "title": "Project repository",
+          "description": "cloned in service",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "branch": {
+          "title": "Specific branch to use",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "asCodeServerRoot": {
+          "title": "Open the service in the clone folder",
+          "type": "boolean",
+          "default": false,
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "networking": {
+      "title": "Network access",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/networking.json"
+      },
+      "properties": {
+        "user": {
+          "title": "Ports",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable access to your service through specific ports",
+              "type": "boolean",
+              "default": false
+            },
+            "port": {
+              "title": "Port number to expose",
+              "type": "integer",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            },
+            "ports": {
+              "title": "Port numbers to expose",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "uniqueItems": true,
+                "default": 5000
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "title": "Third party services discovery",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "title": "Discover Hive Metastore services",
+          "type": "boolean",
+          "default": true
+        },
+        "mlflow": {
+          "title": "Discover MLflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "metaflow": {
+          "title": "Discover Metaflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "chromadb": {
+          "title": "Discover ChromaDB services",
+          "type": "boolean",
+          "default": true
+        },
+        "milvus": {
+          "title": "Discover Milvus services",
+          "type": "boolean",
+          "default": true
+        },
+        "postgresql": {
+          "title": "Discover PostgreSQL services",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "security": {
+      "title": "Security",
+      "type": "object",
+      "properties": {
+        "password": {
+          "title": "Service password",
+          "type": "string",
+          "default": "changeme",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{service.oneTimePassword}}",
+            "overwriteSchemaWith": "ide/password.json"
+          }
+        },
+        "networkPolicy": {
+          "title": "Network access policy",
+          "type": "object",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "title": "Only allow access from the same namespace",
+              "type": "boolean",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "description": "Array of sources allowed to have network access to your service",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "NodeSelector",
+      "default": {},
+      "x-onyxia": {
+        "overwriteDefaultWith": "region.nodeSelector",
+        "overwriteSchemaWith": "nodeSelector-gpu.json"
+      }
+    },
+    "ingress": {
+      "title": "Ingress Details",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/ingress.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        },
+        "useCertManager": {
+          "type": "boolean",
+          "description": "Whether CertManager should be used to generate a certificate",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.useCertManager"
+          }
+        },
+        "certManagerClusterIssuer": {
+          "type": "string",
+          "description": "certManager cluster issuer",
+          "title": "CertManager Cluster Issuer",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
+          }
+        },
+        "useTlsSecret": {
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tlsSecretName": {
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "repository.json"
+      },
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
+    },
+    "startupProbe": {
+      "description": "Startup probe",
+      "type": "object",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "default": 60
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "default": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "default": 2
+        }
+      },
+      "default": {
+        "failureThreshold": 60,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "timeoutSeconds": 2
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.startupProbe",
+        "overwriteSchemaWith": "ide/startupProbe.json"
+      }
+    },
+    "tolerations": {
+      "description": "Array of tolerations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "userPreferences": {
+      "title": "User Preferences",
+      "type": "object",
+      "properties": {
+        "darkMode": {
+          "type": "boolean",
+          "description": "dark mode is or is not enabled",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.darkMode"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Preferred language",
+          "default": "en",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.lang"
+          }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Continue, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            },
+            "useLegacyCompletionsEndpoint": {
+              "title": "use legacy completions endpoint",
+              "type": "boolean",
+              "default": true,
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
+              }
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "proxy": {
+      "description": "It can be used to inject proxy settings in the services",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "proxy.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Inject proxy settings",
+          "default": false
+        },
+        "httpProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTP.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTPS.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "enterprise local domain that should not take proxy comma separated",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "description": "It can be used to inject certificate authority into the services, if the Helm chart in the catalog allows it you can bind this value to the Helm chart value to add some certificate authorities in the pod.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "certificates.json"
+      },
+      "default": {},
+      "properties": {
+        "cacerts": {
+          "type": "string",
+          "description": "String of concatenated CA certificates. Alternatively a target URL can be provided.",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "pathToCaBundle": {
+          "type": "string",
+          "description": "String path where a bundle is made or injected by third party solution",
+          "default": "/usr/local/share/ca-certificates/",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "Warning message",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/message.json"
+      },
+      "properties": {
+        "fr": {
+          "type": "string",
+          "description": "message \u00e0 ajouter dans les notes",
+          "default": ""
+        },
+        "en": {
+          "type": "string",
+          "description": "message to add in notes",
+          "default": ""
+        }
+      }
+    },
+    "runtimeClassName": {
+      "type": "string",
+      "description": "Runtime Class Name",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/runtimeClassName.json"
+      }
+    }
+  }
+}

--- a/charts/marimo-tensorflow-gpu/values.yaml
+++ b/charts/marimo-tensorflow-gpu/values.yaml
@@ -1,0 +1,169 @@
+global:
+  suspend: false
+service:
+  initContainer:
+    image: inseefrlab/onyxia-base:latest
+    pullPolicy: IfNotPresent
+  image:
+    version: pacordonnier/marimo-tensorflow:py3.13.12-gpu
+    pullPolicy: IfNotPresent
+    custom:
+      enabled: false
+      version: pacordonnier/marimo-tensorflow:py3.13.12-gpu
+security:
+  password: changeme
+  networkPolicy:
+    enabled: false
+    from: []
+  allowlist:
+    enabled: false
+    ip: 0.0.0.0/0
+init:
+  standardInitPath: /opt/onyxia-init.sh
+  regionInit: ''
+  regionInitCheckSum: ''
+  personalInit: ''
+  personalInitArgs: ''
+extraEnvVars: []
+s3:
+  enabled: false
+  secretName: ''
+  accessKeyId: ''
+  endpoint: ''
+  defaultRegion: ''
+  secretAccessKey: ''
+  sessionToken: ''
+  pathStyleAccess: false
+  workingDirectoryPath: ''
+vault:
+  enabled: false
+  secretName: ''
+  token: ''
+  url: ''
+  mount: ''
+  secret: ''
+  directory: ''
+git:
+  enabled: true
+  secretName: ''
+  name: ''
+  email: ''
+  cache: ''
+  branch: ''
+  asCodeServerRoot: false
+repository:
+  configMapName: ''
+  pipRepository: ''
+  condaRepository: ''
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+  chromadb: true
+  milvus: true
+  postgresql: true
+hive:
+  secretName: ''
+mlflow:
+  secretName: ''
+metaflow:
+  secretName: ''
+chromadb:
+  secretName: ''
+milvus:
+  secretName: ''
+coresite:
+  secretName: ''
+postgresql:
+  secretName: ''
+replicaCount: 1
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ''
+environment:
+  user: onyxia
+  group: users
+kubernetes:
+  enabled: true
+  role: view
+podAnnotations: {}
+podSecurityContext:
+  fsGroup: 100
+securityContext: {}
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    port: 2718
+  user:
+    enabled: false
+    port: 5000
+    ports: []
+ingress:
+  enabled: false
+  tls: true
+  ingressClassName: ''
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  path: /
+  userPath: /
+  useCertManager: false
+  certManagerClusterIssuer: ''
+  useTlsSecret: false
+  tlsSecretName: ''
+route:
+  enabled: false
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  tls:
+    termination: edge
+  wildcardPolicy: None
+resources: {}
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 10Gi
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+nodeSelector: {}
+tolerations: []
+affinity: {}
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+userPreferences:
+  darkMode: false
+  language: en
+  aiAssistant:
+    enabled: false
+    model: ''
+    provider: ''
+    apiBase: ''
+    apiKey: ''
+    secretName: ''
+    useLegacyCompletionsEndpoint: false
+openshiftSCC:
+  enabled: false
+  scc: ''
+proxy:
+  enabled: false
+  noProxy: ''
+  httpProxy: ''
+  httpsProxy: ''
+certificates: {}
+message:
+  fr: ''
+  en: ''
+runtimeClassName: ''

--- a/charts/marimo-tensorflow/.helmignore
+++ b/charts/marimo-tensorflow/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/marimo-tensorflow/Chart.yaml
+++ b/charts/marimo-tensorflow/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: marimo-tensorflow
+description: Marimo reactive Python notebook with Python and the deep-learning framework TensorFlow.
+icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/marimo.png
+keywords:
+- Marimo
+- Python
+home: https://marimo.io/
+sources:
+- https://github.com/InseeFrLab/images-datascience
+- https://github.com/InseeFrLab/helm-charts-interactive-services
+type: application
+version: 0.0.1
+dependencies:
+- name: library-chart
+  version: 2.0.4
+  repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/marimo-tensorflow/templates/NOTES.txt
+++ b/charts/marimo-tensorflow/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}

--- a/charts/marimo-tensorflow/templates/NOTES.txt
+++ b/charts/marimo-tensorflow/templates/NOTES.txt
@@ -1,1 +1,1 @@
-{{- template "library-chart.notes" (dict "serviceName" "Visual Studio Code (Python)" "context" $) -}}
+{{- template "library-chart.notes" (dict "serviceName" "Marimo (Python)" "context" $) -}}

--- a/charts/marimo-tensorflow/templates/configmap-repository.yaml
+++ b/charts/marimo-tensorflow/templates/configmap-repository.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapRepository" . }}

--- a/charts/marimo-tensorflow/templates/ingress-user.yaml
+++ b/charts/marimo-tensorflow/templates/ingress-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingressUser" . }}

--- a/charts/marimo-tensorflow/templates/ingress.yaml
+++ b/charts/marimo-tensorflow/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.ingress" . }}

--- a/charts/marimo-tensorflow/templates/networkpolicy-ingress.yaml
+++ b/charts/marimo-tensorflow/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicyIngress" . }}

--- a/charts/marimo-tensorflow/templates/networkpolicy.yaml
+++ b/charts/marimo-tensorflow/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/marimo-tensorflow/templates/pvc.yaml
+++ b/charts/marimo-tensorflow/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/marimo-tensorflow/templates/role-binding-scc.yaml
+++ b/charts/marimo-tensorflow/templates/role-binding-scc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBindingSCC" . }}

--- a/charts/marimo-tensorflow/templates/role-binding.yaml
+++ b/charts/marimo-tensorflow/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/marimo-tensorflow/templates/route-user.yaml
+++ b/charts/marimo-tensorflow/templates/route-user.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.routeUser" . }}

--- a/charts/marimo-tensorflow/templates/route.yaml
+++ b/charts/marimo-tensorflow/templates/route.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.route" . }}

--- a/charts/marimo-tensorflow/templates/secret-assistant.yaml
+++ b/charts/marimo-tensorflow/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistant" . }}

--- a/charts/marimo-tensorflow/templates/secret-cacerts.yaml
+++ b/charts/marimo-tensorflow/templates/secret-cacerts.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretCacerts" . }}

--- a/charts/marimo-tensorflow/templates/secret-chromadb.yaml
+++ b/charts/marimo-tensorflow/templates/secret-chromadb.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretChromaDB" . }}

--- a/charts/marimo-tensorflow/templates/secret-extraenv.yaml
+++ b/charts/marimo-tensorflow/templates/secret-extraenv.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretExtraEnv" . }}

--- a/charts/marimo-tensorflow/templates/secret-git.yaml
+++ b/charts/marimo-tensorflow/templates/secret-git.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretGit" . }}

--- a/charts/marimo-tensorflow/templates/secret-hive.yaml
+++ b/charts/marimo-tensorflow/templates/secret-hive.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretHive" . }}

--- a/charts/marimo-tensorflow/templates/secret-metaflow.yaml
+++ b/charts/marimo-tensorflow/templates/secret-metaflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMetaflow" . }}

--- a/charts/marimo-tensorflow/templates/secret-milvus.yaml
+++ b/charts/marimo-tensorflow/templates/secret-milvus.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMilvus" . }}

--- a/charts/marimo-tensorflow/templates/secret-mlflow.yaml
+++ b/charts/marimo-tensorflow/templates/secret-mlflow.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretMLFlow" . }}

--- a/charts/marimo-tensorflow/templates/secret-postgresql.yaml
+++ b/charts/marimo-tensorflow/templates/secret-postgresql.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretPostgreSQL" . }}

--- a/charts/marimo-tensorflow/templates/secret-proxy.yaml
+++ b/charts/marimo-tensorflow/templates/secret-proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretProxy" . }}

--- a/charts/marimo-tensorflow/templates/secret-s3.yaml
+++ b/charts/marimo-tensorflow/templates/secret-s3.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretS3" . }}

--- a/charts/marimo-tensorflow/templates/secret-token.yaml
+++ b/charts/marimo-tensorflow/templates/secret-token.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretToken" . }}

--- a/charts/marimo-tensorflow/templates/secret-vault.yaml
+++ b/charts/marimo-tensorflow/templates/secret-vault.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretVault" . }}

--- a/charts/marimo-tensorflow/templates/service.yaml
+++ b/charts/marimo-tensorflow/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/marimo-tensorflow/templates/serviceaccount.yaml
+++ b/charts/marimo-tensorflow/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/marimo-tensorflow/templates/statefulset.yaml
+++ b/charts/marimo-tensorflow/templates/statefulset.yaml
@@ -1,0 +1,316 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if not (.Values.autoscaling).enabled }}
+  {{- if (.Values.global).suspend }}
+  replicas: 0
+  {{- else }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (.Values.git).enabled }}
+        checksum/git: {{ include (print $.Template.BasePath "/secret-git.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.s3).enabled }}
+        checksum/s3: {{ include (print $.Template.BasePath "/secret-s3.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (.Values.vault).enabled }}
+        checksum/vault: {{ include (print $.Template.BasePath "/secret-vault.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretHive" .))) }}
+        checksum/hive: {{ include (print $.Template.BasePath "/secret-hive.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMetaflow" .))) }}
+        checksum/metaflow: {{ include (print $.Template.BasePath "/secret-metaflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+        checksum/mlflow: {{ include (print $.Template.BasePath "/secret-mlflow.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+        checksum/chromadb: {{ include (print $.Template.BasePath "/secret-chromadb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+        checksum/milvus: {{ include (print $.Template.BasePath "/secret-milvus.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+        checksum/postgresql: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "library-chart.repository.enabled"  .) }}
+        checksum/repository: {{ include (print $.Template.BasePath "/configmap-repository.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        checksum/cacerts: {{ .Values.certificates.cacerts | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.runtimeClassName -}}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
+      volumes:
+        - name: config-files
+          emptyDir: {}
+        - name: home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        {{- if (.Values.proxy).enabled }}
+        - name: secret-proxy
+          secret:
+            secretName: {{ include "library-chart.secretNameProxy" . }}
+        {{- end }}
+        {{- if .Values.discovery.hive }}
+        - name: secret-hive
+          secret:
+            secretName: {{ include "library-chart.secretNameHive" . }}
+        {{- end }}
+        {{- if .Values.discovery.metaflow }}
+        - name: secret-metaflow
+          secret:
+            secretName: {{ include "library-chart.secretNameMetaflow" . }}
+        {{- end }}
+        {{- if and .Values.certificates .Values.certificates.cacerts }}
+        - name: cacerts
+          secret:
+            secretName: {{ include "library-chart.secretNameCacerts" . }}
+        {{- end }}
+        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistant" . }}
+        {{- end }}
+        - name: token
+          secret:
+            secretName: {{ include "library-chart.secretNameToken" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: make-secrets-writable
+          image: {{ .Values.service.initContainer.image }}
+          imagePullPolicy: {{ .Values.service.initContainer.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              echo 'initContainer make-secrets-writable is started';
+              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              mkdir /dest/continue
+              cp /src/continue/config.yaml /dest/continue/config.yaml
+              {{- end }}
+              {{- if .Values.discovery.hive }}
+              mkdir /dest/hive;
+              cp /src/hive/hive-site.xml /dest/hive/hive-site.xml;
+              {{- end }}
+              {{- if .Values.discovery.metaflow }}
+              mkdir /dest/metaflow;
+              cp /src/metaflow/config.json /dest/metaflow/config.json;
+              {{- end }}
+              {{- if and .Values.certificates .Values.certificates.cacerts }}
+              mkdir /dest/cacerts;
+              {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
+              curl -s $(cat /cacerts/ca-certs.url) -o /tmp/ca.pem
+              {{- else }}
+              cp /cacerts/ca.pem /tmp/ca.pem
+              {{- end }}
+              awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
+              {{- end }}
+          volumeMounts:
+            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            - name: secret-assistant
+              mountPath: /src/continue
+            {{- end }}
+            - name: config-files
+              mountPath: /dest
+            {{- if and .Values.certificates .Values.certificates.cacerts }}
+            - name: cacerts
+              mountPath: /cacerts
+            {{- end }}
+            {{- if .Values.discovery.hive }}
+            - name: secret-hive
+              mountPath: /src/hive
+            {{- end }}
+            {{- if .Values.discovery.metaflow }}
+            - name : secret-metaflow
+              mountPath: /src/metaflow
+            {{- end }}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.service.image.custom.enabled }}
+          image: "{{ .Values.service.image.custom.version }}"
+          {{- else }}
+          image: "{{ .Values.service.image.version }}"
+          {{- end }}
+          command: ["/bin/sh","-c"]
+          {{- if .Values.git.asCodeServerRoot }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
+          {{- else }}
+          args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
+          {{- end }}
+          imagePullPolicy: {{ .Values.service.image.pullPolicy }}
+          env:
+            {{- if .Values.init.regionInit }}
+            - name: REGION_INIT_SCRIPT
+              value: {{ .Values.init.regionInit }}
+            {{- end }}
+            {{- if .Values.init.regionInitCheckSum }}
+            - name: REGION_INIT_SCRIPT_CHECKSUM
+              value: {{ .Values.init.regionInitCheckSum }}
+            {{- end }}
+            {{- if .Values.init.personalInit }}
+            - name: PERSONAL_INIT_SCRIPT
+              value: {{ .Values.init.personalInit }}
+            {{- end }}
+            {{- if .Values.init.personalInitArgs }}
+            - name: PERSONAL_INIT_ARGS
+              value: {{ .Values.init.personalInitArgs }}
+            {{- end }}
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: ROOT_PROJECT_DIRECTORY
+              value: /home/{{ .Values.environment.user }}/work
+            {{- if .Values.userPreferences.darkMode }}
+            - name: DARK_MODE
+              value: "true"
+            {{- end }}
+            - name: UV_CACHE_DIR
+              value: /home/{{ .Values.environment.user }}/work/.cache/uv
+          envFrom:
+            - secretRef:
+                name : {{ include "library-chart.secretNameToken" . }}
+            {{- if (.Values.git).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameGit" . }}
+            {{- end }}
+            {{- if (.Values.s3).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameS3" . }}
+            {{- end }}
+            {{- if (.Values.vault).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameVault" . }}
+            {{- end }}
+            {{- if (.Values.proxy).enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameProxy" . }}
+            {{- end }}
+            {{- if (include "library-chart.repository.enabled" .) }}
+            - configMapRef:
+                name: {{ include "library-chart.configMapNameRepository" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMLFlow" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMLFlow" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretPostgreSQL" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNamePostgreSQL" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretChromaDB" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameChromaDB" . }}
+            {{- end }}
+            {{- if not (empty (trim (include "library-chart.secretMilvus" .))) }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameMilvus" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameExtraEnv" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 2
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          {{- if hasKey .Values "startupProbe" }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+            - name: token
+              mountPath: /home/{{ .Values.environment.user }}/.token
+              readOnly: true
+            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.continue
+              subPath: continue
+              name: config-files
+            {{- end }}
+            {{- if (.Values.discovery).hive }}
+            - name: config-files
+              mountPath: /usr/local/lib/hive/conf/hive-site.xml
+              subPath: hive/hive-site.xml
+            {{- end }}
+            {{- if (.Values.discovery).metaflow }}
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.metaflowconfig
+              subPath: metaflow
+            {{- end }}
+            {{- if (.Values.certificates).pathToCaBundle }}
+            - name: config-files
+              mountPath: {{ .Values.certificates.pathToCaBundle }}
+              subPath: cacerts
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/marimo-tensorflow/templates/tests/test-connection.yaml
+++ b/charts/marimo-tensorflow/templates/tests/test-connection.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.testConnection" . }}

--- a/charts/marimo-tensorflow/values.schema.json
+++ b/charts/marimo-tensorflow/values.schema.json
@@ -1,0 +1,1133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "service": {
+      "title": "Service",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Docker image",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "title": "Pull image from registry",
+              "type": "string",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "title": "Name of the service's Docker image",
+              "type": "string",
+              "default": "pacordonnier/marimo-tensorflow:py3.13.12",
+              "listEnum": [
+                "pacordonnier/marimo-tensorflow:py3.13.12",
+                "pacordonnier/marimo-tensorflow:py3.12.13"
+              ],
+              "render": "list",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              }
+            },
+            "custom": {
+              "title": "Custom image",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Use a custom image instead",
+                  "type": "boolean",
+                  "default": false,
+                  "x-onyxia": {
+                    "overwriteSchemaWith": "ide/customImage.json"
+                  }
+                },
+                "version": {
+                  "title": "Name of the custom image",
+                  "type": "string",
+                  "default": "pacordonnier/marimo-tensorflow:py3.13.12",
+                  "hidden": {
+                    "value": false,
+                    "path": "enabled",
+                    "isPathRelative": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources (CPU/RAM)",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/resources.json"
+      },
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Guaranteed CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuRequest",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Guaranteed memory allocation",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryRequest",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Maximum CPU allocation",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.cpuLimit",
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Maximum memory allocation",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory",
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.resources.memoryLimit",
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/persistence.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Create a persistent volume",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "title": "Persistent volume size",
+          "type": "string",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "overwriteDefaultWith": "region.resources.disk",
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "init": {
+      "title": "Initialization scripts",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/init.json"
+      },
+      "properties": {
+        "regionInit": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptUrl}}"
+          }
+        },
+        "regionInitCheckSum": {
+          "type": "string",
+          "description": "region initialization script",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.initScriptCheckSum}}"
+          }
+        },
+        "personalInit": {
+          "title": "Use a custom script (URL)",
+          "type": "string",
+          "default": ""
+        },
+        "personalInitArgs": {
+          "title": "Arguments for the custom script",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "extraEnvVars": {
+      "title": "Environment variables available within your service",
+      "type": "array",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/extraenv.json"
+      },
+      "items": {
+        "title": "",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "VAR_NAME",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "value": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "title": "Kubernetes permissions",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/role.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Kubernetes access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "role": {
+          "title": "Kubernetes role",
+          "description": "access is restricted to your own namespace",
+          "type": "string",
+          "default": "view",
+          "hidden": {
+            "value": false,
+            "path": "kubernetes/enabled"
+          },
+          "listEnum": [
+            "view",
+            "edit",
+            "admin"
+          ],
+          "render": "list"
+        }
+      }
+    },
+    "openshiftSCC": {
+      "description": "configuration for openshift compatibility",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/openshiftSCC.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "enable rolebinding with openshift scc",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.enabled"
+          }
+        },
+        "scc": {
+          "type": "string",
+          "description": "name of scc for rolebinding",
+          "default": "anyuid",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "region.openshiftSCC.scc"
+          }
+        }
+      }
+    },
+    "vault": {
+      "title": "Vault access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/vault.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable Vault access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "token": {
+          "title": "Vault token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "url": {
+          "title": "Vault server URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_ADDR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "mount": {
+          "title": "Secret engine",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_MOUNT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "directory": {
+          "title": "Top-level directory",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{vault.VAULT_TOP_DIR}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secret": {
+          "title": "Path to the secret to load",
+          "description": "The secret will be converted into a list of environment variables",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "s3": {
+      "title": "S3 object storage",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/s3.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable S3 access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "accessKeyId": {
+          "title": "Access Key ID",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "s3.AWS_ACCESS_KEY_ID"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "endpoint": {
+          "title": "S3 endpoint URL",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "defaultRegion": {
+          "title": "Default region",
+          "type": "string",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "secretAccessKey": {
+          "title": "Secret Access Key",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "sessionToken": {
+          "title": "Session token",
+          "type": "string",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "pathStyleAccess": {
+          "title": "Path-style access",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.pathStyleAccess}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "workingDirectoryPath": {
+          "title": "Working directory path",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.workingDirectoryPath}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "git": {
+      "title": "Git access",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/git.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable git access from within the service",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "title": "User name",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.name}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "email": {
+          "title": "User email",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.email}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "cache": {
+          "title": "Credentials caching duration",
+          "description": "(in seconds)",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.credentials_cache_duration}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "token": {
+          "title": "Personal Access Token",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.token}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "repository": {
+          "title": "Project repository",
+          "description": "cloned in service",
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{git.project}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "branch": {
+          "title": "Specific branch to use",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        },
+        "asCodeServerRoot": {
+          "title": "Open the service in the clone folder",
+          "type": "boolean",
+          "default": false,
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          }
+        }
+      }
+    },
+    "networking": {
+      "title": "Network access",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/networking.json"
+      },
+      "properties": {
+        "user": {
+          "title": "Ports",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable access to your service through specific ports",
+              "type": "boolean",
+              "default": false
+            },
+            "port": {
+              "title": "Port number to expose",
+              "type": "integer",
+              "hidden": {
+                "value": false,
+                "path": "networking/user/enabled"
+              },
+              "default": 5000
+            },
+            "ports": {
+              "title": "Port numbers to expose",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "uniqueItems": true,
+                "default": 5000
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "discovery": {
+      "title": "Third party services discovery",
+      "type": "object",
+      "properties": {
+        "hive": {
+          "title": "Discover Hive Metastore services",
+          "type": "boolean",
+          "default": true
+        },
+        "mlflow": {
+          "title": "Discover MLflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "metaflow": {
+          "title": "Discover Metaflow services",
+          "type": "boolean",
+          "default": true
+        },
+        "chromadb": {
+          "title": "Discover ChromaDB services",
+          "type": "boolean",
+          "default": true
+        },
+        "milvus": {
+          "title": "Discover Milvus services",
+          "type": "boolean",
+          "default": true
+        },
+        "postgresql": {
+          "title": "Discover PostgreSQL services",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "security": {
+      "title": "Security",
+      "type": "object",
+      "properties": {
+        "password": {
+          "title": "Service password",
+          "type": "string",
+          "default": "changeme",
+          "render": "password",
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{service.oneTimePassword}}",
+            "overwriteSchemaWith": "ide/password.json"
+          }
+        },
+        "networkPolicy": {
+          "title": "Network access policy",
+          "type": "object",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "title": "Only allow access from the same namespace",
+              "type": "boolean",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "description": "Array of sources allowed to have network access to your service",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "title": "Node selector",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      },
+      "x-onyxia": {
+        "hidden": false,
+        "overwriteDefaultWith": "region.nodeSelector",
+        "overwriteSchemaWith": "nodeSelector.json"
+      }
+    },
+    "ingress": {
+      "title": "Ingress Details",
+      "type": "object",
+      "form": true,
+      "x-onyxia": {
+        "overwriteSchemaWith": "ide/ingress.json"
+      },
+      "properties": {
+        "enabled": {
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        },
+        "ingressClassName": {
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
+        },
+        "useCertManager": {
+          "type": "boolean",
+          "description": "Whether CertManager should be used to generate a certificate",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.useCertManager"
+          }
+        },
+        "certManagerClusterIssuer": {
+          "type": "string",
+          "description": "certManager cluster issuer",
+          "title": "CertManager Cluster Issuer",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.certManagerClusterIssuer"
+          }
+        },
+        "useTlsSecret": {
+          "type": "boolean",
+          "description": "Whether you want to use the specified secretName in ingress tls",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tlsSecretName": {
+          "type": "string",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+          }
+        },
+        "userHostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-user.{{k8s.domain}}"
+          }
+        }
+      }
+    },
+    "repository": {
+      "description": "python repositories for pip and conda",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "repository.json"
+      },
+      "properties": {
+        "pipRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.pypiProxyUrl}}"
+          }
+        },
+        "condaRepository": {
+          "type": "string",
+          "description": "python repository for pip",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{packageRepositoryInjection.condaProxyUrl}}"
+          }
+        }
+      }
+    },
+    "startupProbe": {
+      "description": "Startup probe",
+      "type": "object",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "default": 60
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "default": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "default": 2
+        }
+      },
+      "default": {
+        "failureThreshold": 60,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "timeoutSeconds": 2
+      },
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.startupProbe",
+        "overwriteSchemaWith": "ide/startupProbe.json"
+      }
+    },
+    "tolerations": {
+      "description": "Array of tolerations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "userPreferences": {
+      "title": "User Preferences",
+      "type": "object",
+      "properties": {
+        "darkMode": {
+          "type": "boolean",
+          "description": "dark mode is or is not enabled",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.darkMode"
+          }
+        },
+        "language": {
+          "type": "string",
+          "description": "Preferred language",
+          "default": "en",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "user.lang"
+          }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Continue, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            },
+            "useLegacyCompletionsEndpoint": {
+              "title": "use legacy completions endpoint",
+              "type": "boolean",
+              "default": true,
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
+              }
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "proxy": {
+      "description": "It can be used to inject proxy settings in the services",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "proxy.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Inject proxy settings",
+          "default": false
+        },
+        "httpProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTP.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "URL of the enterprise proxy for the region for HTTPS.",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "enterprise local domain that should not take proxy comma separated",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "proxy/enabled"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "description": "It can be used to inject certificate authority into the services, if the Helm chart in the catalog allows it you can bind this value to the Helm chart value to add some certificate authorities in the pod.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "certificates.json"
+      },
+      "default": {},
+      "properties": {
+        "cacerts": {
+          "type": "string",
+          "description": "String of concatenated CA certificates. Alternatively a target URL can be provided.",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "pathToCaBundle": {
+          "type": "string",
+          "description": "String path where a bundle is made or injected by third party solution",
+          "default": "/usr/local/share/ca-certificates/",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "Warning message",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/message.json"
+      },
+      "properties": {
+        "fr": {
+          "type": "string",
+          "description": "message \u00e0 ajouter dans les notes",
+          "default": ""
+        },
+        "en": {
+          "type": "string",
+          "description": "message to add in notes",
+          "default": ""
+        }
+      }
+    },
+    "runtimeClassName": {
+      "type": "string",
+      "description": "Runtime Class Name",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "ide/runtimeClassName.json"
+      }
+    }
+  }
+}

--- a/charts/marimo-tensorflow/values.yaml
+++ b/charts/marimo-tensorflow/values.yaml
@@ -1,0 +1,169 @@
+global:
+  suspend: false
+service:
+  initContainer:
+    image: inseefrlab/onyxia-base:latest
+    pullPolicy: IfNotPresent
+  image:
+    version: pacordonnier/marimo-tensorflow:py3.13.12
+    pullPolicy: IfNotPresent
+    custom:
+      enabled: false
+      version: pacordonnier/marimo-tensorflow:py3.13.12
+security:
+  password: changeme
+  networkPolicy:
+    enabled: false
+    from: []
+  allowlist:
+    enabled: false
+    ip: 0.0.0.0/0
+init:
+  standardInitPath: /opt/onyxia-init.sh
+  regionInit: ''
+  regionInitCheckSum: ''
+  personalInit: ''
+  personalInitArgs: ''
+extraEnvVars: []
+s3:
+  enabled: false
+  secretName: ''
+  accessKeyId: ''
+  endpoint: ''
+  defaultRegion: ''
+  secretAccessKey: ''
+  sessionToken: ''
+  pathStyleAccess: false
+  workingDirectoryPath: ''
+vault:
+  enabled: false
+  secretName: ''
+  token: ''
+  url: ''
+  mount: ''
+  secret: ''
+  directory: ''
+git:
+  enabled: true
+  secretName: ''
+  name: ''
+  email: ''
+  cache: ''
+  branch: ''
+  asCodeServerRoot: false
+repository:
+  configMapName: ''
+  pipRepository: ''
+  condaRepository: ''
+discovery:
+  hive: true
+  mlflow: true
+  metaflow: true
+  chromadb: true
+  milvus: true
+  postgresql: true
+hive:
+  secretName: ''
+mlflow:
+  secretName: ''
+metaflow:
+  secretName: ''
+chromadb:
+  secretName: ''
+milvus:
+  secretName: ''
+coresite:
+  secretName: ''
+postgresql:
+  secretName: ''
+replicaCount: 1
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ''
+environment:
+  user: onyxia
+  group: users
+kubernetes:
+  enabled: true
+  role: view
+podAnnotations: {}
+podSecurityContext:
+  fsGroup: 100
+securityContext: {}
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    port: 2718
+  user:
+    enabled: false
+    port: 5000
+    ports: []
+ingress:
+  enabled: false
+  tls: true
+  ingressClassName: ''
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  path: /
+  userPath: /
+  useCertManager: false
+  certManagerClusterIssuer: ''
+  useTlsSecret: false
+  tlsSecretName: ''
+route:
+  enabled: false
+  annotations: []
+  hostname: chart-example.local
+  userHostname: chart-example-user.local
+  tls:
+    termination: edge
+  wildcardPolicy: None
+resources: {}
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 10Gi
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+nodeSelector: {}
+tolerations: []
+affinity: {}
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+userPreferences:
+  darkMode: false
+  language: en
+  aiAssistant:
+    enabled: false
+    model: ''
+    provider: ''
+    apiBase: ''
+    apiKey: ''
+    secretName: ''
+    useLegacyCompletionsEndpoint: false
+openshiftSCC:
+  enabled: false
+  scc: ''
+proxy:
+  enabled: false
+  noProxy: ''
+  httpProxy: ''
+  httpsProxy: ''
+certificates: {}
+message:
+  fr: ''
+  en: ''
+runtimeClassName: ''


### PR DESCRIPTION
<!--
 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

The PR aims to add Marimo and all differents flavors to the interactive services catalog.

The PR is pretty huge as I added all the differents flavors for marimo, copying what was done for VSCode:

- marimo-python
- marimo-python-gpu
- marimo-pyspark
- marimo-tensorflow
- marimo-tensorflow-gpu
- marimo-pytorch
- marimo-pytorch-gpu

For each flavour, I copied the equivalent vscode-* chart. Here's what I did after copying to 'adapt' vscode to marimo

- in Chart.yaml
  - change name, description and other metadatas, set version to 0.0.1
- README.md
  - delete its content, to be created by CI
- values.schema.yaml
  - set the image name from inseefrlab/vscode-(xxx) to pacordonnier/marimo-(xxx)
- values.yaml
  - set image version
  - set networking.service.port to 2718 (default marimo port)
-  templates folder:

Marimo does not support reading token/password from ENV, so needs to mount the secret-token as volumes

In statefulset.yaml, args are now:

```yaml
{{- if .Values.git.asCodeServerRoot }}
args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work/$(basename $GIT_REPOSITORY) .git"]
{{- else }}
args: ["{{ .Values.init.standardInitPath }} marimo edit --host 0.0.0.0 --token-password-file ~/.token/PASSWORD /home/{{ .Values.environment.user }}/work"]
{{- end }}
``` 

volume for secret token needs to be declared in statefulset.yaml

```yaml
spec.template.spec.volumes:
        - name: token
          secret:
            secretName: {{ include "library-chart.secretNameToken" . }}
```

volumeMounts:

```yaml
spec.template.spec.containers[0].volumesMounts
- name: token  
  mountPath: /home/{{ .Values.environment.user }}/.token
   readOnly: true
```

Feel free to add my forked to catalog to your onyxia instances in order to play with Marimo. All the images for marimo has been built and pushed to dockerhub in my own name. 

Here's the catalog to add to your onyxia instance:

```yaml
catalogs:
      - id: ide-adaltas
        name:
          en: Development environments - Adaltas
          fr: Environnements de développement - Adaltas
          de: Entwicklungsumgebungen - Adaltas
          fi: Kehitysympäristöt - Adaltas
          it: Ambienti di sviluppo - Adaltas
          nl: Ontwikkelingsomgevingen - Adaltas
          "no": Utviklingsmiljøer - Adaltas
          zh-CN: 开发环境 - Adaltas
        maintainer: stdin@adaltas.com
        location: https://adaltas.github.io/helm-charts-interactive-services
        status: PROD
        highlightedCharts:
          - marimo-python
          - marimo-python-gpu
          - marimo-tensorflow
          - marimo-tensorflow-gpu
          - marimo-pyspark
          - marimo-pytorch
          - marimo-pytorch-gpu
        type: helm
        skipTlsVerify: false
        caFile:
        allowSharing: false
        visible:
          user: true
          project: true
        username:
        password:
        multipleServicesMode: latest
```

### Checklist

- [x] Chart version bumped in `Chart.yaml`
- [x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
