### PR TITLE
feat: add generic IA secret and opencode/continue config support across charts

### DIFF
--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,8 +24,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.1
+version: 3.2.2
 dependencies:
   - name: library-chart
-    version: 2.1.0
+    version: 2.1.1
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,8 +24,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0
+version: 3.2.1
 dependencies:
   - name: library-chart
-    version: 2.0.8
+    version: 2.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,8 +24,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.5
+version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.0.4
+    version: 2.0.8
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.1.5
+    version: 2.1.6
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.2
 dependencies:
   - name: library-chart
-    version: 2.1.1
+    version: 2.1.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.1.2
+    version: 2.1.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.3
+version: 3.2.0
 dependencies:
   - name: library-chart
     version: 2.1.2

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.2
+version: 3.2.3
 dependencies:
   - name: library-chart
     version: 2.1.2

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.1.3
+    version: 2.1.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-pyspark/templates/secret-assistant.yaml
+++ b/charts/jupyter-pyspark/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistantJupyter" . }}

--- a/charts/jupyter-pyspark/templates/secret-assistant.yaml
+++ b/charts/jupyter-pyspark/templates/secret-assistant.yaml
@@ -1,1 +1,0 @@
-{{ include "library-chart.secretAssistantJupyter" . }}

--- a/charts/jupyter-pyspark/templates/secret-opencode.yaml
+++ b/charts/jupyter-pyspark/templates/secret-opencode.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretOpencode" . }}

--- a/charts/jupyter-pyspark/templates/statefulset.yaml
+++ b/charts/jupyter-pyspark/templates/statefulset.yaml
@@ -128,6 +128,9 @@ spec:
         - name: secret-opencode
           secret:
             secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -150,6 +153,8 @@ spec:
               {{ if $aiAssistant.enabled }}
               mkdir -p /dest/opencode
               cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
+              mkdir -p /dest/jupyter-ai
+              cp /src/jupyter-ai/config.json /dest/jupyter-ai/config.json
               {{- end }}
               {{- if .Values.s3.enabled }}
               mkdir /dest/coresite;
@@ -184,6 +189,8 @@ spec:
             {{- if $aiAssistant.enabled }}
             - name: secret-opencode
               mountPath: /src/opencode
+            - name: secret-assistant
+              mountPath: /src/jupyter-ai
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -341,6 +348,9 @@ spec:
             - name: config-files
               mountPath: /home/{{ .Values.environment.user }}/.config/opencode
               subPath: opencode
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai/config.json
+              subPath: jupyter-ai/config.json
             {{- end }}
             - mountPath: /home/{{ .Values.environment.user }}/work
               subPath: work

--- a/charts/jupyter-pyspark/templates/statefulset.yaml
+++ b/charts/jupyter-pyspark/templates/statefulset.yaml
@@ -125,9 +125,9 @@ spec:
             secretName: {{ include "library-chart.secretNameCacerts" . }}
         {{- end }}
         {{- if $aiAssistant.enabled }}
-        - name: secret-assistant
+        - name: secret-opencode
           secret:
-            secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
+            secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -147,9 +147,9 @@ spec:
             - -c
             - |
               echo 'initContainer make-configmaps-writable is started';
-              mkdir -p /dest/jupyter-ai
               {{ if $aiAssistant.enabled }}
-              cp /src/jupyter-ai/config.json /dest/jupyter-ai/config.json
+              mkdir -p /dest/opencode
+              cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
               {{- end }}
               {{- if .Values.s3.enabled }}
               mkdir /dest/coresite;
@@ -182,8 +182,8 @@ spec:
               {{- end }}
           volumeMounts:
             {{- if $aiAssistant.enabled }}
-            - name: secret-assistant
-              mountPath: /src/jupyter-ai
+            - name: secret-opencode
+              mountPath: /src/opencode
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -270,11 +270,9 @@ spec:
               value: /home/{{ .Values.environment.user }}/work/.cache/uv
             {{- if $aiAssistant.enabled }}
             - name: OPENAI_API_KEY
-              value: {{ $aiAssistant.apiKey }}
+              value: {{ get ($aiAssistant.activeProvider | default dict) "apiKey" | default "" | quote }}
             - name: OPENAI_BASE_URL
-              value: {{ $aiAssistant.apiBase }}
-            - name: ENABLE_JUPYTER_AI_EXTENSION
-              value: "{{ $aiAssistant.enabled }}"
+              value: {{ get ($aiAssistant.activeProvider | default dict) "apiBase" | default "" | quote }}
             {{- end }}
           envFrom:
             - secretRef:
@@ -341,8 +339,8 @@ spec:
           volumeMounts:
             {{- if $aiAssistant.enabled }}
             - name: config-files
-              mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai
-              subPath: jupyter-ai
+              mountPath: /home/{{ .Values.environment.user }}/.config/opencode
+              subPath: opencode
             {{- end }}
             - mountPath: /home/{{ .Values.environment.user }}/work
               subPath: work

--- a/charts/jupyter-pyspark/templates/statefulset.yaml
+++ b/charts/jupyter-pyspark/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "library-chart.fullname" . -}}
+{{- $aiAssistant := include "library-chart.aiAssistant" . | fromJson -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -123,7 +124,7 @@ spec:
           secret:
             secretName: {{ include "library-chart.secretNameCacerts" . }}
         {{- end }}
-        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        {{- if $aiAssistant.enabled }}
         - name: secret-assistant
           secret:
             secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
@@ -147,7 +148,7 @@ spec:
             - |
               echo 'initContainer make-configmaps-writable is started';
               mkdir -p /dest/jupyter-ai
-              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              {{ if $aiAssistant.enabled }}
               cp /src/jupyter-ai/config.json /dest/jupyter-ai/config.json
               {{- end }}
               {{- if .Values.s3.enabled }}
@@ -180,7 +181,7 @@ spec:
               awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
               {{- end }}
           volumeMounts:
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - name: secret-assistant
               mountPath: /src/jupyter-ai
             {{- end }}
@@ -267,13 +268,13 @@ spec:
             {{- end }}
             - name: UV_CACHE_DIR
               value: /home/{{ .Values.environment.user }}/work/.cache/uv
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - name: OPENAI_API_KEY
-              value: {{ .Values.userPreferences.aiAssistant.apiKey }}
+              value: {{ $aiAssistant.apiKey }}
             - name: OPENAI_BASE_URL
-              value: {{ .Values.userPreferences.aiAssistant.apiBase }}
+              value: {{ $aiAssistant.apiBase }}
             - name: ENABLE_JUPYTER_AI_EXTENSION
-              value: "{{ .Values.userPreferences.aiAssistant.enabled }}"
+              value: "{{ $aiAssistant.enabled }}"
             {{- end }}
           envFrom:
             - secretRef:
@@ -338,7 +339,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - name: config-files
               mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai
               subPath: jupyter-ai

--- a/charts/jupyter-pyspark/templates/statefulset.yaml
+++ b/charts/jupyter-pyspark/templates/statefulset.yaml
@@ -128,9 +128,6 @@ spec:
         - name: secret-opencode
           secret:
             secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
-        - name: secret-assistant
-          secret:
-            secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -153,8 +150,6 @@ spec:
               {{ if $aiAssistant.enabled }}
               mkdir -p /dest/opencode
               cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
-              mkdir -p /dest/jupyter-ai
-              cp /src/jupyter-ai/config.json /dest/jupyter-ai/config.json
               {{- end }}
               {{- if .Values.s3.enabled }}
               mkdir /dest/coresite;
@@ -189,8 +184,6 @@ spec:
             {{- if $aiAssistant.enabled }}
             - name: secret-opencode
               mountPath: /src/opencode
-            - name: secret-assistant
-              mountPath: /src/jupyter-ai
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -348,9 +341,6 @@ spec:
             - name: config-files
               mountPath: /home/{{ .Values.environment.user }}/.config/opencode
               subPath: opencode
-            - name: config-files
-              mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai/config.json
-              subPath: jupyter-ai/config.json
             {{- end }}
             - mountPath: /home/{{ .Values.environment.user }}/work
               subPath: work

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -592,7 +592,7 @@
       "title": "AI Assistant",
       "type": "object",
       "x-onyxia": {
-        "overwriteSchemaWith": "aiAssistant-jupyter.json"
+        "overwriteSchemaWith": "ai.json"
       },
       "properties": {
         "enabled": {
@@ -606,32 +606,70 @@
         "activeProvider": {
           "type": "object",
           "default": {},
+          "properties": {
+            "id": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.id}}"
+              }
+            },
+            "name": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.name}}"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.provider}}"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiBase}}"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiKey}}"
+              }
+            },
+            "selectedModel": {
+              "type": "string",
+              "listEnum": [""],
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.selectedModel}}",
+                "overwriteListEnumWith": "{{ai.activeProvider.models}}"
+              }
+            },
+            "models": {
+              "type": "array",
+              "default": [],
+              "items": { "type": "string" },
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "{{ai.activeProvider.models}}"
+              }
+            }
+          },
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
-          },
-          "properties": {
-            "id": { "type": "string", "default": "" },
-            "name": { "type": "string", "default": "" },
-            "provider": { "type": "string", "default": "" },
-            "apiBase": { "type": "string", "default": "" },
-            "apiKey": { "type": "string", "default": "" },
-            "selectedModel": { "type": "string", "default": "" },
-            "models": { "type": "array", "default": [], "items": { "type": "string" } }
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
         "providers": {
           "type": "array",
           "default": [],
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
           "items": {
             "type": "object",
             "properties": {
@@ -641,11 +679,20 @@
               "apiBase": { "type": "string", "default": "" },
               "apiKey": { "type": "string", "default": "" },
               "selectedModel": { "type": "string", "default": "" },
-              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+              "models": {
+                "type": "array",
+                "default": [],
+                "items": { "type": "string" }
+              }
             }
           },
           "x-onyxia": {
             "overwriteDefaultWith": "{{ai.providers}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
           }
         }
       }

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -673,16 +673,48 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "default": "" },
-              "name": { "type": "string", "default": "" },
-              "provider": { "type": "string", "default": "" },
-              "apiBase": { "type": "string", "default": "" },
-              "apiKey": { "type": "string", "default": "" },
-              "selectedModel": { "type": "string", "default": "" },
+              "id": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{id}}" }
+              },
+              "name": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{name}}" }
+              },
+              "provider": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{provider}}" }
+              },
+              "apiBase": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiBase}}" }
+              },
+              "apiKey": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiKey}}" }
+              },
+              "selectedModel": {
+                "type": "string",
+                "listEnum": [],
+                "default": "",
+                "x-onyxia": {
+                  "overwriteDefaultWith": "{{selectedModel}}",
+                  "overwriteListEnumWith": "{{models}}"
+                }
+              },
               "models": {
                 "type": "array",
                 "default": [],
-                "items": { "type": "string" }
+                "items": { "type": "string" },
+                "x-onyxia": {
+                  "hidden": true,
+                  "overwriteDefaultWith": "{{models}}"
+                }
               }
             }
           },

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -1030,6 +1030,73 @@
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
           }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            }
+          }
         }
       }
     },

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -596,6 +596,90 @@
         }
       }
     },
+    "ai": {
+      "title": "AI Assistant",
+      "type": "object",
+      "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
+      "x-onyxia": {
+        "overwriteSchemaWith": "aiAssistant-jupyter.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable AI assistant tools",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.enabled}}"
+          }
+        },
+        "model": {
+          "title": "Model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.model}}"
+          }
+        },
+        "modelProvider": {
+          "title": "Model provider",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.modelProvider}}"
+          }
+        },
+        "embeddingsProvider": {
+          "title": "Embeddings provider",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.embeddingsProvider}}"
+          }
+        },
+        "apiBase": {
+          "title": "API base URL",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiBase}}"
+          }
+        },
+        "apiKey": {
+          "title": "API key",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiKey}}"
+          }
+        }
+      }
+    },
     "networking": {
       "title": "Network access",
       "type": "object",
@@ -896,84 +980,6 @@
           "x-onyxia": {
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
-          }
-        },
-        "aiAssistant": {
-          "title": "AI Assistant",
-          "type": "object",
-          "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
-          "x-onyxia": {
-            "overwriteSchemaWith": "aiAssistant-jupyter.json"
-          },
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false,
-              "hidden": true,
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
-              }
-            },
-            "model": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.model"
-              }
-            },
-            "modelProvider": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.modelProvider"
-              }
-            },
-            "embeddingsProvider": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.embeddingsProvider"
-              }
-            },
-            "apiBase": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
-              }
-            },
-            "apiKey": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
-              }
-            }
           }
         }
       }

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -14,11 +14,7 @@
               "title": "Pull image from registry",
               "type": "string",
               "default": "IfNotPresent",
-              "enum": [
-                "IfNotPresent",
-                "Always",
-                "Never"
-              ]
+              "enum": ["IfNotPresent", "Always", "Never"]
             },
             "version": {
               "title": "Name of the service's Docker image",
@@ -319,11 +315,7 @@
             "value": false,
             "path": "kubernetes/enabled"
           },
-          "listEnum": [
-            "view",
-            "edit",
-            "admin"
-          ],
+          "listEnum": ["view", "edit", "admin"],
           "render": "list"
         }
       }
@@ -599,7 +591,6 @@
     "ai": {
       "title": "AI Assistant",
       "type": "object",
-      "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
       "x-onyxia": {
         "overwriteSchemaWith": "aiAssistant-jupyter.json"
       },
@@ -612,70 +603,49 @@
             "overwriteDefaultWith": "{{ai.enabled}}"
           }
         },
-        "model": {
-          "title": "Model",
-          "type": "string",
-          "default": "",
+        "activeProvider": {
+          "type": "object",
+          "default": {},
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
+          "properties": {
+            "id": { "type": "string", "default": "" },
+            "name": { "type": "string", "default": "" },
+            "provider": { "type": "string", "default": "" },
+            "apiBase": { "type": "string", "default": "" },
+            "apiKey": { "type": "string", "default": "" },
+            "selectedModel": { "type": "string", "default": "" },
+            "models": { "type": "array", "default": [], "items": { "type": "string" } }
+          },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.model}}"
+            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
-        "modelProvider": {
-          "title": "Model provider",
-          "type": "string",
-          "default": "",
+        "providers": {
+          "type": "array",
+          "default": [],
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.modelProvider}}"
-          }
-        },
-        "embeddingsProvider": {
-          "title": "Embeddings provider",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "default": "" },
+              "name": { "type": "string", "default": "" },
+              "provider": { "type": "string", "default": "" },
+              "apiBase": { "type": "string", "default": "" },
+              "apiKey": { "type": "string", "default": "" },
+              "selectedModel": { "type": "string", "default": "" },
+              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+            }
           },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.embeddingsProvider}}"
-          }
-        },
-        "apiBase": {
-          "title": "API base URL",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiBase}}"
-          }
-        },
-        "apiKey": {
-          "title": "API key",
-          "type": "string",
-          "default": "",
-          "render": "password",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiKey}}"
+            "overwriteDefaultWith": "{{ai.providers}}"
           }
         }
       }
@@ -1164,7 +1134,7 @@
         }
       }
     },
-    "runtimeClassName" : {
+    "runtimeClassName": {
       "type": "string",
       "description": "Runtime Class Name",
       "default": "",

--- a/charts/jupyter-pyspark/values.yaml
+++ b/charts/jupyter-pyspark/values.yaml
@@ -270,16 +270,18 @@ startupProbe:
   successThreshold: 1
   timeoutSeconds: 2
 
+ai:
+  enabled: false
+  secretName: ""  # Generated based on the service's name if empty or not set
+  model: ""
+  modelProvider: ""
+  embeddingsProvider: ""
+  apiBase: ""
+  apiKey: ""
+
 userPreferences:
   darkMode: false
   language: "en"
-  aiAssistant:
-    enabled: false
-    modelProvider: ""
-    embeddingsProvider: ""
-    apiBase: ""
-    apiKey: ""
-    secretName: ""  # Generated based on the service's name if empty or not set
 
 openshiftSCC:
   enabled: false

--- a/charts/jupyter-pyspark/values.yaml
+++ b/charts/jupyter-pyspark/values.yaml
@@ -273,11 +273,8 @@ startupProbe:
 ai:
   enabled: false
   secretName: ""  # Generated based on the service's name if empty or not set
-  model: ""
-  modelProvider: ""
-  embeddingsProvider: ""
-  apiBase: ""
-  apiKey: ""
+  activeProvider: {}
+  providers: []
 
 userPreferences:
   darkMode: false

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.1
+version: 2.5.2
 dependencies:
   - name: library-chart
-    version: 2.1.0
+    version: 2.1.1
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.2
+version: 2.5.3
 dependencies:
   - name: library-chart
     version: 2.1.2

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.9
+version: 2.5.0
 dependencies:
   - name: library-chart
-    version: 2.0.4
+    version: 2.0.8
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.5.0
 dependencies:
   - name: library-chart
-    version: 2.1.3
+    version: 2.1.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.5.0
 dependencies:
   - name: library-chart
-    version: 2.1.5
+    version: 2.1.6
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.1
 dependencies:
   - name: library-chart
-    version: 2.0.8
+    version: 2.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.5.2
 dependencies:
   - name: library-chart
-    version: 2.1.1
+    version: 2.1.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.3
+version: 2.5.0
 dependencies:
   - name: library-chart
     version: 2.1.2

--- a/charts/jupyter-python/Chart.yaml
+++ b/charts/jupyter-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.5.0
 dependencies:
   - name: library-chart
-    version: 2.1.2
+    version: 2.1.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/jupyter-python/templates/secret-assistant.yaml
+++ b/charts/jupyter-python/templates/secret-assistant.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretAssistantJupyter" . }}

--- a/charts/jupyter-python/templates/secret-assistant.yaml
+++ b/charts/jupyter-python/templates/secret-assistant.yaml
@@ -1,1 +1,0 @@
-{{ include "library-chart.secretAssistantJupyter" . }}

--- a/charts/jupyter-python/templates/secret-opencode.yaml
+++ b/charts/jupyter-python/templates/secret-opencode.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretOpencode" . }}

--- a/charts/jupyter-python/templates/statefulset.yaml
+++ b/charts/jupyter-python/templates/statefulset.yaml
@@ -103,6 +103,9 @@ spec:
         - name: secret-opencode
           secret:
             secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
+        - name: secret-assistant
+          secret:
+            secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -125,6 +128,8 @@ spec:
               {{ if $aiAssistant.enabled }}
               mkdir -p /dest/opencode
               cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
+              mkdir -p /dest/jupyter-ai
+              cp /src/jupyter-ai/config.json /dest/jupyter-ai/config.json
               {{- end }}
               {{- if .Values.discovery.hive }}
               mkdir /dest/hive;
@@ -147,6 +152,8 @@ spec:
             {{- if $aiAssistant.enabled }}
             - name: secret-opencode
               mountPath: /src/opencode
+            - name: secret-assistant
+              mountPath: /src/jupyter-ai
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -292,6 +299,9 @@ spec:
             - name: config-files
               mountPath: /home/{{ .Values.environment.user }}/.config/opencode
               subPath: opencode
+            - name: config-files
+              mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai/config.json
+              subPath: jupyter-ai/config.json
             {{- end }}
             - mountPath: /home/{{ .Values.environment.user }}/work
               subPath: work

--- a/charts/jupyter-python/templates/statefulset.yaml
+++ b/charts/jupyter-python/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "library-chart.fullname" . -}}
+{{- $aiAssistant := include "library-chart.aiAssistant" . | fromJson -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -98,7 +99,7 @@ spec:
           secret:
             secretName: {{ include "library-chart.secretNameCacerts" . }}
         {{- end }}
-        {{- if (.Values.userPreferences.aiAssistant).enabled }}
+        {{- if $aiAssistant.enabled }}
         - name: secret-assistant
           secret:
             secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
@@ -121,7 +122,7 @@ spec:
             - -c
             - |
               echo 'initContainer make-secrets-writable is started';
-              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              {{ if $aiAssistant.enabled }}
               mkdir -p /dest/jupyter-ai
               cp /src/jupyter-ai/config.json /dest/jupyter-ai/config.json
               {{- end }}
@@ -143,7 +144,7 @@ spec:
               awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
               {{- end }}
           volumeMounts:
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - name: secret-assistant
               mountPath: /src/jupyter-ai
             {{- end }}
@@ -218,13 +219,13 @@ spec:
             {{- end }}
             - name: UV_CACHE_DIR
               value: /home/{{ .Values.environment.user }}/work/.cache/uv
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - name: OPENAI_API_KEY
-              value: {{ .Values.userPreferences.aiAssistant.apiKey }}
+              value: {{ $aiAssistant.apiKey }}
             - name: OPENAI_BASE_URL
-              value: {{ .Values.userPreferences.aiAssistant.apiBase }}
+              value: {{ $aiAssistant.apiBase }}
             - name: ENABLE_JUPYTER_AI_EXTENSION
-              value: "{{ .Values.userPreferences.aiAssistant.enabled }}"
+              value: "{{ $aiAssistant.enabled }}"
             {{- end }}
           envFrom:
             - secretRef:
@@ -289,7 +290,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - name: config-files
               mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai/config.json
               subPath: jupyter-ai/config.json

--- a/charts/jupyter-python/templates/statefulset.yaml
+++ b/charts/jupyter-python/templates/statefulset.yaml
@@ -103,9 +103,6 @@ spec:
         - name: secret-opencode
           secret:
             secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
-        - name: secret-assistant
-          secret:
-            secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -152,8 +149,6 @@ spec:
             {{- if $aiAssistant.enabled }}
             - name: secret-opencode
               mountPath: /src/opencode
-            - name: secret-assistant
-              mountPath: /src/jupyter-ai
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -299,9 +294,6 @@ spec:
             - name: config-files
               mountPath: /home/{{ .Values.environment.user }}/.config/opencode
               subPath: opencode
-            - name: config-files
-              mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai/config.json
-              subPath: jupyter-ai/config.json
             {{- end }}
             - mountPath: /home/{{ .Values.environment.user }}/work
               subPath: work

--- a/charts/jupyter-python/templates/statefulset.yaml
+++ b/charts/jupyter-python/templates/statefulset.yaml
@@ -100,9 +100,9 @@ spec:
             secretName: {{ include "library-chart.secretNameCacerts" . }}
         {{- end }}
         {{- if $aiAssistant.enabled }}
-        - name: secret-assistant
+        - name: secret-opencode
           secret:
-            secretName: {{ include "library-chart.secretNameAssistantJupyter" . }}
+            secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -123,8 +123,8 @@ spec:
             - |
               echo 'initContainer make-secrets-writable is started';
               {{ if $aiAssistant.enabled }}
-              mkdir -p /dest/jupyter-ai
-              cp /src/jupyter-ai/config.json /dest/jupyter-ai/config.json
+              mkdir -p /dest/opencode
+              cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
               {{- end }}
               {{- if .Values.discovery.hive }}
               mkdir /dest/hive;
@@ -145,8 +145,8 @@ spec:
               {{- end }}
           volumeMounts:
             {{- if $aiAssistant.enabled }}
-            - name: secret-assistant
-              mountPath: /src/jupyter-ai
+            - name: secret-opencode
+              mountPath: /src/opencode
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -221,11 +221,9 @@ spec:
               value: /home/{{ .Values.environment.user }}/work/.cache/uv
             {{- if $aiAssistant.enabled }}
             - name: OPENAI_API_KEY
-              value: {{ $aiAssistant.apiKey }}
+              value: {{ get ($aiAssistant.activeProvider | default dict) "apiKey" | default "" | quote }}
             - name: OPENAI_BASE_URL
-              value: {{ $aiAssistant.apiBase }}
-            - name: ENABLE_JUPYTER_AI_EXTENSION
-              value: "{{ $aiAssistant.enabled }}"
+              value: {{ get ($aiAssistant.activeProvider | default dict) "apiBase" | default "" | quote }}
             {{- end }}
           envFrom:
             - secretRef:
@@ -292,8 +290,8 @@ spec:
           volumeMounts:
             {{- if $aiAssistant.enabled }}
             - name: config-files
-              mountPath: /home/{{ .Values.environment.user }}/.local/share/jupyter/jupyter_ai/config.json
-              subPath: jupyter-ai/config.json
+              mountPath: /home/{{ .Values.environment.user }}/.config/opencode
+              subPath: opencode
             {{- end }}
             - mountPath: /home/{{ .Values.environment.user }}/work
               subPath: work

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -548,32 +548,70 @@
         "activeProvider": {
           "type": "object",
           "default": {},
+          "properties": {
+            "id": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.id}}"
+              }
+            },
+            "name": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.name}}"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.provider}}"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiBase}}"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiKey}}"
+              }
+            },
+            "selectedModel": {
+              "type": "string",
+              "listEnum": [""],
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.selectedModel}}",
+                "overwriteListEnumWith": "{{ai.activeProvider.models}}"
+              }
+            },
+            "models": {
+              "type": "array",
+              "default": [],
+              "items": { "type": "string" },
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "{{ai.activeProvider.models}}"
+              }
+            }
+          },
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
-          },
-          "properties": {
-            "id": { "type": "string", "default": "" },
-            "name": { "type": "string", "default": "" },
-            "provider": { "type": "string", "default": "" },
-            "apiBase": { "type": "string", "default": "" },
-            "apiKey": { "type": "string", "default": "" },
-            "selectedModel": { "type": "string", "default": "" },
-            "models": { "type": "array", "default": [], "items": { "type": "string" } }
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
         "providers": {
           "type": "array",
           "default": [],
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
           "items": {
             "type": "object",
             "properties": {
@@ -583,11 +621,20 @@
               "apiBase": { "type": "string", "default": "" },
               "apiKey": { "type": "string", "default": "" },
               "selectedModel": { "type": "string", "default": "" },
-              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+              "models": {
+                "type": "array",
+                "default": [],
+                "items": { "type": "string" }
+              }
             }
           },
           "x-onyxia": {
             "overwriteDefaultWith": "{{ai.providers}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
           }
         }
       }

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -14,11 +14,7 @@
               "title": "Pull image from registry",
               "type": "string",
               "default": "IfNotPresent",
-              "enum": [
-                "IfNotPresent",
-                "Always",
-                "Never"
-              ]
+              "enum": ["IfNotPresent", "Always", "Never"]
             },
             "version": {
               "title": "Name of the service's Docker image",
@@ -261,11 +257,7 @@
             "value": false,
             "path": "kubernetes/enabled"
           },
-          "listEnum": [
-            "view",
-            "edit",
-            "admin"
-          ],
+          "listEnum": ["view", "edit", "admin"],
           "render": "list"
         }
       }
@@ -541,7 +533,6 @@
     "ai": {
       "title": "AI Assistant",
       "type": "object",
-      "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
       "x-onyxia": {
         "overwriteSchemaWith": "aiAssistant-jupyter.json"
       },
@@ -554,70 +545,49 @@
             "overwriteDefaultWith": "{{ai.enabled}}"
           }
         },
-        "model": {
-          "title": "Model",
-          "type": "string",
-          "default": "",
+        "activeProvider": {
+          "type": "object",
+          "default": {},
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
+          "properties": {
+            "id": { "type": "string", "default": "" },
+            "name": { "type": "string", "default": "" },
+            "provider": { "type": "string", "default": "" },
+            "apiBase": { "type": "string", "default": "" },
+            "apiKey": { "type": "string", "default": "" },
+            "selectedModel": { "type": "string", "default": "" },
+            "models": { "type": "array", "default": [], "items": { "type": "string" } }
+          },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.model}}"
+            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
-        "modelProvider": {
-          "title": "Model provider",
-          "type": "string",
-          "default": "",
+        "providers": {
+          "type": "array",
+          "default": [],
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.modelProvider}}"
-          }
-        },
-        "embeddingsProvider": {
-          "title": "Embeddings provider",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "default": "" },
+              "name": { "type": "string", "default": "" },
+              "provider": { "type": "string", "default": "" },
+              "apiBase": { "type": "string", "default": "" },
+              "apiKey": { "type": "string", "default": "" },
+              "selectedModel": { "type": "string", "default": "" },
+              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+            }
           },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.embeddingsProvider}}"
-          }
-        },
-        "apiBase": {
-          "title": "API base URL",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiBase}}"
-          }
-        },
-        "apiKey": {
-          "title": "API key",
-          "type": "string",
-          "default": "",
-          "render": "password",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiKey}}"
+            "overwriteDefaultWith": "{{ai.providers}}"
           }
         }
       }
@@ -859,7 +829,7 @@
             "hidden": true
           }
         },
-        "tlsSecretName":{
+        "tlsSecretName": {
           "type": "string",
           "default": "",
           "x-onyxia": {
@@ -1106,7 +1076,7 @@
         }
       }
     },
-    "runtimeClassName" : {
+    "runtimeClassName": {
       "type": "string",
       "description": "Runtime Class Name",
       "default": "",

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -1051,6 +1051,73 @@
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
           }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            }
+          }
         }
       }
     },

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -538,6 +538,90 @@
         }
       }
     },
+    "ai": {
+      "title": "AI Assistant",
+      "type": "object",
+      "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
+      "x-onyxia": {
+        "overwriteSchemaWith": "aiAssistant-jupyter.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable AI assistant tools",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.enabled}}"
+          }
+        },
+        "model": {
+          "title": "Model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.model}}"
+          }
+        },
+        "modelProvider": {
+          "title": "Model provider",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.modelProvider}}"
+          }
+        },
+        "embeddingsProvider": {
+          "title": "Embeddings provider",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.embeddingsProvider}}"
+          }
+        },
+        "apiBase": {
+          "title": "API base URL",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiBase}}"
+          }
+        },
+        "apiKey": {
+          "title": "API key",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiKey}}"
+          }
+        }
+      }
+    },
     "networking": {
       "title": "Network access",
       "type": "object",
@@ -917,84 +1001,6 @@
           "x-onyxia": {
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
-          }
-        },
-        "aiAssistant":{
-          "title": "AI Assistant",
-          "type": "object",
-          "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
-          "x-onyxia": {
-            "overwriteSchemaWith": "aiAssistant-jupyter.json"
-          },
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false,
-              "hidden": true,
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
-              }
-            },
-            "model": {
-              "type": "string",
-              "default":"",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.model"
-              }
-            },
-            "modelProvider": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.modelProvider"
-              }
-            },
-            "embeddingsProvider": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.embeddingsProvider"
-              }
-            },
-            "apiBase":{
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
-              }
-            },
-            "apiKey":{
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
-              }
-            }
           }
         }
       }

--- a/charts/jupyter-python/values.schema.json
+++ b/charts/jupyter-python/values.schema.json
@@ -615,16 +615,48 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "default": "" },
-              "name": { "type": "string", "default": "" },
-              "provider": { "type": "string", "default": "" },
-              "apiBase": { "type": "string", "default": "" },
-              "apiKey": { "type": "string", "default": "" },
-              "selectedModel": { "type": "string", "default": "" },
+              "id": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{id}}" }
+              },
+              "name": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{name}}" }
+              },
+              "provider": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{provider}}" }
+              },
+              "apiBase": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiBase}}" }
+              },
+              "apiKey": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiKey}}" }
+              },
+              "selectedModel": {
+                "type": "string",
+                "listEnum": [],
+                "default": "",
+                "x-onyxia": {
+                  "overwriteDefaultWith": "{{selectedModel}}",
+                  "overwriteListEnumWith": "{{models}}"
+                }
+              },
               "models": {
                 "type": "array",
                 "default": [],
-                "items": { "type": "string" }
+                "items": { "type": "string" },
+                "x-onyxia": {
+                  "hidden": true,
+                  "overwriteDefaultWith": "{{models}}"
+                }
               }
             }
           },

--- a/charts/jupyter-python/values.yaml
+++ b/charts/jupyter-python/values.yaml
@@ -237,16 +237,18 @@ startupProbe:
   successThreshold: 1
   timeoutSeconds: 2
 
+ai:
+  enabled: false
+  secretName: ""  # Generated based on the service's name if empty or not set
+  model: ""
+  modelProvider: ""
+  embeddingsProvider: ""
+  apiBase: ""
+  apiKey: ""
+
 userPreferences:
   darkMode: false
   language: "en"
-  aiAssistant:
-    enabled: false
-    modelProvider: ""
-    embeddingsProvider: ""
-    apiBase: ""
-    apiKey: ""
-    secretName: ""  # Generated based on the service's name if empty or not set
 
 openshiftSCC:
   enabled: false

--- a/charts/jupyter-python/values.yaml
+++ b/charts/jupyter-python/values.yaml
@@ -240,11 +240,8 @@ startupProbe:
 ai:
   enabled: false
   secretName: ""  # Generated based on the service's name if empty or not set
-  model: ""
-  modelProvider: ""
-  embeddingsProvider: ""
-  apiBase: ""
-  apiKey: ""
+  activeProvider: {}
+  providers: []
 
 userPreferences:
   darkMode: false

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.1
+version: 2.5.3
 dependencies:
   - name: library-chart
-    version: 2.1.0
+    version: 2.1.1
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.5.3
 dependencies:
   - name: library-chart
-    version: 2.1.3
+    version: 2.1.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.5.3
 dependencies:
   - name: library-chart
-    version: 2.1.1
+    version: 2.1.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.1
 dependencies:
   - name: library-chart
-    version: 2.0.8
+    version: 2.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.5.3
 dependencies:
   - name: library-chart
-    version: 2.1.2
+    version: 2.1.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.7
+version: 2.5.0
 dependencies:
   - name: library-chart
-    version: 2.0.4
+    version: 2.0.8
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/rstudio/templates/secret-ia.yaml
+++ b/charts/rstudio/templates/secret-ia.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretIa" . }}

--- a/charts/rstudio/templates/secret-opencode.yaml
+++ b/charts/rstudio/templates/secret-opencode.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretOpencode" . }}

--- a/charts/rstudio/templates/statefulset.yaml
+++ b/charts/rstudio/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "library-chart.fullname" . -}}
+{{- $aiAssistant := include "library-chart.aiAssistant" . | fromJson -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -71,6 +72,11 @@ spec:
           secret:
             secretName: {{ include "library-chart.secretNameCacerts" . }}
           {{- end }}
+          {{- if $aiAssistant.enabled }}
+        - name: secret-opencode
+          secret:
+            secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
+          {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -89,6 +95,10 @@ spec:
             - -c
             - |
               echo 'initContainer make-secrets-writable is started';
+              {{- if $aiAssistant.enabled }}
+              mkdir /dest/opencode
+              cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
+              {{- end }}
               {{- if and .Values.certificates .Values.certificates.cacerts }}
               mkdir /dest/cacerts;
               {{- if regexMatch "^https?://" .Values.certificates.cacerts }}
@@ -99,6 +109,10 @@ spec:
               awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
               {{- end }}
           volumeMounts:
+            {{- if $aiAssistant.enabled }}
+            - name: secret-opencode
+              mountPath: /src/opencode
+            {{- end }}
             - name: config-files
               mountPath: /dest
               {{- if and .Values.certificates .Values.certificates.cacerts }}
@@ -185,6 +199,10 @@ spec:
             {{- end }}
             - secretRef:
                 name: {{ include "library-chart.secretNameToken" . }}
+            {{- if $aiAssistant.enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameIa" . }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             - secretRef:
                 name: {{ include "library-chart.secretNameExtraEnv" . }}
@@ -214,6 +232,11 @@ spec:
               name: home
             - mountPath: /dev/shm
               name: dshm
+            {{- if $aiAssistant.enabled }}
+            - mountPath: /home/{{ .Values.environment.user }}/.config/opencode
+              subPath: opencode
+              name: config-files
+            {{- end }}
             {{- if and .Values.certificates .Values.certificates.pathToCaBundle }}
             - name: config-files
               mountPath: {{ .Values.certificates.pathToCaBundle }}

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -548,32 +548,70 @@
         "activeProvider": {
           "type": "object",
           "default": {},
+          "properties": {
+            "id": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.id}}"
+              }
+            },
+            "name": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.name}}"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.provider}}"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiBase}}"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiKey}}"
+              }
+            },
+            "selectedModel": {
+              "type": "string",
+              "listEnum": [""],
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.selectedModel}}",
+                "overwriteListEnumWith": "{{ai.activeProvider.models}}"
+              }
+            },
+            "models": {
+              "type": "array",
+              "default": [],
+              "items": { "type": "string" },
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "{{ai.activeProvider.models}}"
+              }
+            }
+          },
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
-          },
-          "properties": {
-            "id": { "type": "string", "default": "" },
-            "name": { "type": "string", "default": "" },
-            "provider": { "type": "string", "default": "" },
-            "apiBase": { "type": "string", "default": "" },
-            "apiKey": { "type": "string", "default": "" },
-            "selectedModel": { "type": "string", "default": "" },
-            "models": { "type": "array", "default": [], "items": { "type": "string" } }
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
         "providers": {
           "type": "array",
           "default": [],
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
           "items": {
             "type": "object",
             "properties": {
@@ -583,11 +621,20 @@
               "apiBase": { "type": "string", "default": "" },
               "apiKey": { "type": "string", "default": "" },
               "selectedModel": { "type": "string", "default": "" },
-              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+              "models": {
+                "type": "array",
+                "default": [],
+                "items": { "type": "string" }
+              }
             }
           },
           "x-onyxia": {
             "overwriteDefaultWith": "{{ai.providers}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
           }
         }
       }

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -1026,6 +1026,73 @@
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
           }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            }
+          }
         }
       }
     },

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -538,6 +538,89 @@
         }
       }
     },
+    "ai": {
+      "title": "AI Assistant",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ai.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable AI assistant tools",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.enabled}}"
+          }
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.provider}}"
+          }
+        },
+        "model": {
+          "title": "Model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.model}}"
+          }
+        },
+        "embeddingsModel": {
+          "title": "Embeddings model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.embeddingsModel}}"
+          }
+        },
+        "apiBase": {
+          "title": "API base URL",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiBase}}"
+          }
+        },
+        "apiKey": {
+          "title": "API key",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiKey}}"
+          }
+        }
+      }
+    },
     "networking": {
       "title": "Network access",
       "type": "object",

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -14,11 +14,7 @@
               "title": "Pull image from registry",
               "type": "string",
               "default": "IfNotPresent",
-              "enum": [
-                "IfNotPresent",
-                "Always",
-                "Never"
-              ]
+              "enum": ["IfNotPresent", "Always", "Never"]
             },
             "version": {
               "title": "Name of the service's Docker image",
@@ -261,11 +257,7 @@
             "value": false,
             "path": "kubernetes/enabled"
           },
-          "listEnum": [
-            "view",
-            "edit",
-            "admin"
-          ],
+          "listEnum": ["view", "edit", "admin"],
           "render": "list"
         }
       }
@@ -553,70 +545,49 @@
             "overwriteDefaultWith": "{{ai.enabled}}"
           }
         },
-        "provider": {
-          "title": "Provider",
-          "type": "string",
-          "default": "",
+        "activeProvider": {
+          "type": "object",
+          "default": {},
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
+          "properties": {
+            "id": { "type": "string", "default": "" },
+            "name": { "type": "string", "default": "" },
+            "provider": { "type": "string", "default": "" },
+            "apiBase": { "type": "string", "default": "" },
+            "apiKey": { "type": "string", "default": "" },
+            "selectedModel": { "type": "string", "default": "" },
+            "models": { "type": "array", "default": [], "items": { "type": "string" } }
+          },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.provider}}"
+            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
-        "model": {
-          "title": "Model",
-          "type": "string",
-          "default": "",
+        "providers": {
+          "type": "array",
+          "default": [],
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.model}}"
-          }
-        },
-        "embeddingsModel": {
-          "title": "Embeddings model",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "default": "" },
+              "name": { "type": "string", "default": "" },
+              "provider": { "type": "string", "default": "" },
+              "apiBase": { "type": "string", "default": "" },
+              "apiKey": { "type": "string", "default": "" },
+              "selectedModel": { "type": "string", "default": "" },
+              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+            }
           },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.embeddingsModel}}"
-          }
-        },
-        "apiBase": {
-          "title": "API base URL",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiBase}}"
-          }
-        },
-        "apiKey": {
-          "title": "API key",
-          "type": "string",
-          "default": "",
-          "render": "password",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiKey}}"
+            "overwriteDefaultWith": "{{ai.providers}}"
           }
         }
       }
@@ -833,7 +804,7 @@
             "hidden": true
           }
         },
-        "tlsSecretName":{
+        "tlsSecretName": {
           "type": "string",
           "default": "",
           "x-onyxia": {
@@ -1054,7 +1025,7 @@
         }
       }
     },
-    "runtimeClassName" : {
+    "runtimeClassName": {
       "type": "string",
       "description": "Runtime Class Name",
       "default": "",

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -615,16 +615,48 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "default": "" },
-              "name": { "type": "string", "default": "" },
-              "provider": { "type": "string", "default": "" },
-              "apiBase": { "type": "string", "default": "" },
-              "apiKey": { "type": "string", "default": "" },
-              "selectedModel": { "type": "string", "default": "" },
+              "id": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{id}}" }
+              },
+              "name": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{name}}" }
+              },
+              "provider": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{provider}}" }
+              },
+              "apiBase": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiBase}}" }
+              },
+              "apiKey": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiKey}}" }
+              },
+              "selectedModel": {
+                "type": "string",
+                "listEnum": [],
+                "default": "",
+                "x-onyxia": {
+                  "overwriteDefaultWith": "{{selectedModel}}",
+                  "overwriteListEnumWith": "{{models}}"
+                }
+              },
               "models": {
                 "type": "array",
                 "default": [],
-                "items": { "type": "string" }
+                "items": { "type": "string" },
+                "x-onyxia": {
+                  "hidden": true,
+                  "overwriteDefaultWith": "{{models}}"
+                }
               }
             }
           },

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -210,6 +210,15 @@ startupProbe:
   successThreshold: 1
   timeoutSeconds: 2
 
+ai:
+  enabled: false
+  secretName: ""  # Generated based on the service's name if empty or not set
+  provider: ""
+  model: ""
+  embeddingsModel: ""
+  apiBase: ""
+  apiKey: ""
+
 userPreferences:
   darkMode: false
   language: "en"

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -213,11 +213,8 @@ startupProbe:
 ai:
   enabled: false
   secretName: ""  # Generated based on the service's name if empty or not set
-  provider: ""
-  model: ""
-  embeddingsModel: ""
-  apiBase: ""
-  apiKey: ""
+  activeProvider: {}
+  providers: []
 
 userPreferences:
   darkMode: false

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,8 +24,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.1
+version: 3.2.2
 dependencies:
   - name: library-chart
-    version: 2.1.0
+    version: 2.1.1
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,8 +24,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0
+version: 3.2.1
 dependencies:
   - name: library-chart
-    version: 2.0.8
+    version: 2.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.1.5
+    version: 2.1.6
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.2
 dependencies:
   - name: library-chart
-    version: 2.1.1
+    version: 2.1.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,8 +24,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.4
+version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.0.4
+    version: 2.0.8
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.1.2
+    version: 2.1.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.2
+version: 3.2.0
 dependencies:
   - name: library-chart
     version: 2.1.2

--- a/charts/vscode-pyspark/Chart.yaml
+++ b/charts/vscode-pyspark/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 version: 3.2.0
 dependencies:
   - name: library-chart
-    version: 2.1.3
+    version: 2.1.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-pyspark/templates/secret-assistant.yaml
+++ b/charts/vscode-pyspark/templates/secret-assistant.yaml
@@ -1,1 +1,0 @@
-{{ include "library-chart.secretAssistant" . }}

--- a/charts/vscode-pyspark/templates/secret-continue.yaml
+++ b/charts/vscode-pyspark/templates/secret-continue.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretContinue" . }}

--- a/charts/vscode-pyspark/templates/secret-ia.yaml
+++ b/charts/vscode-pyspark/templates/secret-ia.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretIa" . }}

--- a/charts/vscode-pyspark/templates/secret-opencode.yaml
+++ b/charts/vscode-pyspark/templates/secret-opencode.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretOpencode" . }}

--- a/charts/vscode-pyspark/templates/statefulset.yaml
+++ b/charts/vscode-pyspark/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "library-chart.fullname" . -}}
+{{- $aiAssistant := include "library-chart.aiAssistant" . | fromJson -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -120,10 +121,13 @@ spec:
           secret:
             secretName: {{ include "library-chart.secretNameCacerts" . }}
         {{- end }}
-        {{- if (.Values.userPreferences.aiAssistant).enabled }}
-        - name: secret-assistant
+        {{- if $aiAssistant.enabled }}
+        - name: secret-continue
           secret:
-            secretName: {{ include "library-chart.secretNameAssistant" . }}
+            secretName: {{ printf "%s-secretcontinue" (include "library-chart.fullname" .) }}
+        - name: secret-opencode
+          secret:
+            secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -141,9 +145,11 @@ spec:
             - -c
             - |
               echo 'initContainer make-secrets-writable is started';
-              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              {{ if $aiAssistant.enabled }}
               mkdir /dest/continue
               cp /src/continue/config.yaml /dest/continue/config.yaml
+              mkdir /dest/opencode
+              cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
               {{- end }}
               {{- if .Values.s3.enabled }}
               mkdir /dest/coresite;
@@ -175,9 +181,11 @@ spec:
               awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
               {{- end }}
           volumeMounts:
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
-            - name: secret-assistant
+            {{- if $aiAssistant.enabled }}
+            - name: secret-continue
               mountPath: /src/continue
+            - name: secret-opencode
+              mountPath: /src/opencode
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -269,6 +277,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "library-chart.secretNameToken" . }}
+            {{- if $aiAssistant.enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameIa" . }}
+            {{- end }}
             {{- if (.Values.git).enabled }}
             - secretRef:
                 name: {{ include "library-chart.secretNameGit" . }}
@@ -334,9 +346,12 @@ spec:
               name: home
             - mountPath: /dev/shm
               name: dshm
-            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - mountPath: /home/{{ .Values.environment.user }}/.continue
               subPath: continue
+              name: config-files
+            - mountPath: /home/{{ .Values.environment.user }}/.config/opencode
+              subPath: opencode
               name: config-files
             {{- end }}
             {{- if (.Values.s3).enabled }}

--- a/charts/vscode-pyspark/values.schema.json
+++ b/charts/vscode-pyspark/values.schema.json
@@ -667,16 +667,48 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "default": "" },
-              "name": { "type": "string", "default": "" },
-              "provider": { "type": "string", "default": "" },
-              "apiBase": { "type": "string", "default": "" },
-              "apiKey": { "type": "string", "default": "" },
-              "selectedModel": { "type": "string", "default": "" },
+              "id": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{id}}" }
+              },
+              "name": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{name}}" }
+              },
+              "provider": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{provider}}" }
+              },
+              "apiBase": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiBase}}" }
+              },
+              "apiKey": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiKey}}" }
+              },
+              "selectedModel": {
+                "type": "string",
+                "listEnum": [],
+                "default": "",
+                "x-onyxia": {
+                  "overwriteDefaultWith": "{{selectedModel}}",
+                  "overwriteListEnumWith": "{{models}}"
+                }
+              },
               "models": {
                 "type": "array",
                 "default": [],
-                "items": { "type": "string" }
+                "items": { "type": "string" },
+                "x-onyxia": {
+                  "hidden": true,
+                  "overwriteDefaultWith": "{{models}}"
+                }
               }
             }
           },

--- a/charts/vscode-pyspark/values.schema.json
+++ b/charts/vscode-pyspark/values.schema.json
@@ -600,32 +600,70 @@
         "activeProvider": {
           "type": "object",
           "default": {},
+          "properties": {
+            "id": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.id}}"
+              }
+            },
+            "name": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.name}}"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.provider}}"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiBase}}"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiKey}}"
+              }
+            },
+            "selectedModel": {
+              "type": "string",
+              "listEnum": [""],
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.selectedModel}}",
+                "overwriteListEnumWith": "{{ai.activeProvider.models}}"
+              }
+            },
+            "models": {
+              "type": "array",
+              "default": [],
+              "items": { "type": "string" },
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "{{ai.activeProvider.models}}"
+              }
+            }
+          },
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
-          },
-          "properties": {
-            "id": { "type": "string", "default": "" },
-            "name": { "type": "string", "default": "" },
-            "provider": { "type": "string", "default": "" },
-            "apiBase": { "type": "string", "default": "" },
-            "apiKey": { "type": "string", "default": "" },
-            "selectedModel": { "type": "string", "default": "" },
-            "models": { "type": "array", "default": [], "items": { "type": "string" } }
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
         "providers": {
           "type": "array",
           "default": [],
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
           "items": {
             "type": "object",
             "properties": {
@@ -635,11 +673,20 @@
               "apiBase": { "type": "string", "default": "" },
               "apiKey": { "type": "string", "default": "" },
               "selectedModel": { "type": "string", "default": "" },
-              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+              "models": {
+                "type": "array",
+                "default": [],
+                "items": { "type": "string" }
+              }
             }
           },
           "x-onyxia": {
             "overwriteDefaultWith": "{{ai.providers}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
           }
         }
       }

--- a/charts/vscode-pyspark/values.schema.json
+++ b/charts/vscode-pyspark/values.schema.json
@@ -1143,6 +1143,73 @@
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
           }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            }
+          }
         }
       }
     },

--- a/charts/vscode-pyspark/values.schema.json
+++ b/charts/vscode-pyspark/values.schema.json
@@ -590,6 +590,89 @@
         }
       }
     },
+    "ai": {
+      "title": "AI Assistant",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ai.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable AI assistant tools",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.enabled}}"
+          }
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.provider}}"
+          }
+        },
+        "model": {
+          "title": "Model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.model}}"
+          }
+        },
+        "embeddingsModel": {
+          "title": "Embeddings model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.embeddingsModel}}"
+          }
+        },
+        "apiBase": {
+          "title": "API base URL",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiBase}}"
+          }
+        },
+        "apiKey": {
+          "title": "API key",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiKey}}"
+          }
+        }
+      }
+    },
     "networking": {
       "title": "Network access",
       "type": "object",
@@ -1009,85 +1092,6 @@
           "x-onyxia": {
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
-          }
-        },
-        "aiAssistant":{
-          "title": "AI Assistant",
-          "type": "object",
-          "description": "Configure Continue, an extension to use custom AI code assistants",
-          "x-onyxia": {
-            "overwriteSchemaWith": "aiAssistant.json"
-          },
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false,
-              "hidden": true,
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
-              }
-            },
-            "model": {
-              "type": "string",
-              "default":"",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.model"
-              }
-            },
-            "provider": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
-              }
-            },
-            "apiBase":{
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
-              }
-            },
-            "apiKey":{
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
-              }
-            },
-            "useLegacyCompletionsEndpoint":{
-              "title": "use legacy completions endpoint",
-              "type": "boolean",
-              "default": true,
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
-              }
-            }
           }
         }
       }

--- a/charts/vscode-pyspark/values.schema.json
+++ b/charts/vscode-pyspark/values.schema.json
@@ -14,11 +14,7 @@
               "title": "Pull image from registry",
               "type": "string",
               "default": "IfNotPresent",
-              "enum": [
-                "IfNotPresent",
-                "Always",
-                "Never"
-              ]
+              "enum": ["IfNotPresent", "Always", "Never"]
             },
             "version": {
               "title": "Name of the service's Docker image",
@@ -26,7 +22,7 @@
               "listEnum": [
                 "inseefrlab/onyxia-vscode-pyspark:py3.13.13-spark4.1.1",
                 "inseefrlab/onyxia-vscode-pyspark:py3.12.13-spark4.1.1",
-                 "inseefrlab/onyxia-vscode-pyspark:py3.13.8-spark3.5.7",
+                "inseefrlab/onyxia-vscode-pyspark:py3.13.8-spark3.5.7",
                 "inseefrlab/onyxia-vscode-pyspark:py3.12.13-spark3.5.7"
               ],
               "render": "list",
@@ -303,11 +299,7 @@
             "value": false,
             "path": "kubernetes/enabled"
           },
-          "listEnum": [
-            "view",
-            "edit",
-            "admin"
-          ],
+          "listEnum": ["view", "edit", "admin"],
           "render": "list"
         }
       }
@@ -605,70 +597,49 @@
             "overwriteDefaultWith": "{{ai.enabled}}"
           }
         },
-        "provider": {
-          "title": "Provider",
-          "type": "string",
-          "default": "",
+        "activeProvider": {
+          "type": "object",
+          "default": {},
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
+          "properties": {
+            "id": { "type": "string", "default": "" },
+            "name": { "type": "string", "default": "" },
+            "provider": { "type": "string", "default": "" },
+            "apiBase": { "type": "string", "default": "" },
+            "apiKey": { "type": "string", "default": "" },
+            "selectedModel": { "type": "string", "default": "" },
+            "models": { "type": "array", "default": [], "items": { "type": "string" } }
+          },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.provider}}"
+            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
-        "model": {
-          "title": "Model",
-          "type": "string",
-          "default": "",
+        "providers": {
+          "type": "array",
+          "default": [],
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.model}}"
-          }
-        },
-        "embeddingsModel": {
-          "title": "Embeddings model",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "default": "" },
+              "name": { "type": "string", "default": "" },
+              "provider": { "type": "string", "default": "" },
+              "apiBase": { "type": "string", "default": "" },
+              "apiKey": { "type": "string", "default": "" },
+              "selectedModel": { "type": "string", "default": "" },
+              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+            }
           },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.embeddingsModel}}"
-          }
-        },
-        "apiBase": {
-          "title": "API base URL",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiBase}}"
-          }
-        },
-        "apiKey": {
-          "title": "API key",
-          "type": "string",
-          "default": "",
-          "render": "password",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiKey}}"
+            "overwriteDefaultWith": "{{ai.providers}}"
           }
         }
       }
@@ -909,7 +880,7 @@
             "hidden": true
           }
         },
-        "tlsSecretName":{
+        "tlsSecretName": {
           "type": "string",
           "default": "",
           "x-onyxia": {
@@ -1156,7 +1127,7 @@
         }
       }
     },
-    "runtimeClassName" : {
+    "runtimeClassName": {
       "type": "string",
       "description": "Runtime Class Name",
       "default": "",

--- a/charts/vscode-pyspark/values.yaml
+++ b/charts/vscode-pyspark/values.yaml
@@ -271,17 +271,18 @@ startupProbe:
   successThreshold: 1
   timeoutSeconds: 2
 
+ai:
+  enabled: false
+  secretName: ""  # Generated based on the service's name if empty or not set
+  provider: ""
+  model: ""
+  embeddingsModel: ""
+  apiBase: ""
+  apiKey: ""
+
 userPreferences:
   darkMode: false
   language: "en"
-  aiAssistant:
-    enabled: false
-    model: ""
-    provider: ""
-    apiBase: ""
-    apiKey: ""
-    secretName: ""  # Generated based on the service's name if empty or not set
-    useLegacyCompletionsEndpoint: false
 
 openshiftSCC:
   enabled: false

--- a/charts/vscode-pyspark/values.yaml
+++ b/charts/vscode-pyspark/values.yaml
@@ -274,11 +274,8 @@ startupProbe:
 ai:
   enabled: false
   secretName: ""  # Generated based on the service's name if empty or not set
-  provider: ""
-  model: ""
-  embeddingsModel: ""
-  apiBase: ""
-  apiKey: ""
+  activeProvider: {}
+  providers: []
 
 userPreferences:
   darkMode: false

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.6.0
 dependencies:
   - name: library-chart
     version: 2.1.2

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.7
+version: 2.6.0
 dependencies:
   - name: library-chart
-    version: 2.0.4
+    version: 2.0.7
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.6.0
 dependencies:
   - name: library-chart
-    version: 2.1.3
+    version: 2.1.5
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.6.0
 dependencies:
   - name: library-chart
-    version: 2.0.7
+    version: 2.0.8
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.6.0
 dependencies:
   - name: library-chart
-    version: 2.1.2
+    version: 2.1.3
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 2.6.1
 dependencies:
   - name: library-chart
-    version: 2.0.8
+    version: 2.1.0
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.7.0
 dependencies:
   - name: library-chart
-    version: 2.1.1
+    version: 2.1.2
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -25,5 +25,5 @@ type: application
 version: 2.6.0
 dependencies:
   - name: library-chart
-    version: 2.1.5
+    version: 2.1.6
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.1
+version: 2.7.0
 dependencies:
   - name: library-chart
-    version: 2.1.0
+    version: 2.1.1
     repository: https://inseefrlab.github.io/helm-charts-interactive-services

--- a/charts/vscode-python/templates/secret-assistant.yaml
+++ b/charts/vscode-python/templates/secret-assistant.yaml
@@ -1,1 +1,0 @@
-{{ include "library-chart.secretAssistant" . }}

--- a/charts/vscode-python/templates/secret-continue.yaml
+++ b/charts/vscode-python/templates/secret-continue.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretContinue" . }}

--- a/charts/vscode-python/templates/secret-ia.yaml
+++ b/charts/vscode-python/templates/secret-ia.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretIa" . }}

--- a/charts/vscode-python/templates/secret-opencode.yaml
+++ b/charts/vscode-python/templates/secret-opencode.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretOpencode" . }}

--- a/charts/vscode-python/templates/statefulset.yaml
+++ b/charts/vscode-python/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "library-chart.fullname" . -}}
+{{- $aiAssistant := include "library-chart.aiAssistant" . | fromJson -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -96,10 +97,13 @@ spec:
           secret:
             secretName: {{ include "library-chart.secretNameCacerts" . }}
         {{- end }}
-        {{- if (.Values.userPreferences.aiAssistant).enabled }}
-        - name: secret-assistant
+        {{- if $aiAssistant.enabled }}
+        - name: secret-continue
           secret:
-            secretName: {{ include "library-chart.secretNameAssistant" . }}
+            secretName: {{ printf "%s-secretcontinue" (include "library-chart.fullname" .) }}
+        - name: secret-opencode
+          secret:
+            secretName: {{ printf "%s-secretopencode" (include "library-chart.fullname" .) }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -117,9 +121,11 @@ spec:
             - -c
             - |
               echo 'initContainer make-secrets-writable is started';
-              {{ if (.Values.userPreferences.aiAssistant).enabled }}
+              {{ if $aiAssistant.enabled }}
               mkdir /dest/continue
               cp /src/continue/config.yaml /dest/continue/config.yaml
+              mkdir /dest/opencode
+              cp /src/opencode/opencode.jsonc /dest/opencode/opencode.jsonc
               {{- end }}
               {{- if .Values.discovery.hive }}
               mkdir /dest/hive;
@@ -139,9 +145,11 @@ spec:
               awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "/dest/cacerts/cert." c ".crt"}' < /tmp/ca.pem;
               {{- end }}
           volumeMounts:
-            {{- if (.Values.userPreferences.aiAssistant).enabled }}
-            - name: secret-assistant
+            {{- if $aiAssistant.enabled }}
+            - name: secret-continue
               mountPath: /src/continue
+            - name: secret-opencode
+              mountPath: /src/opencode
             {{- end }}
             - name: config-files
               mountPath: /dest
@@ -211,6 +219,10 @@ spec:
           envFrom:
             - secretRef:
                 name : {{ include "library-chart.secretNameToken" . }}
+            {{- if $aiAssistant.enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameIa" . }}
+            {{- end }}
             {{- if (.Values.git).enabled }}
             - secretRef:
                 name: {{ include "library-chart.secretNameGit" . }}
@@ -276,9 +288,12 @@ spec:
               name: home
             - mountPath: /dev/shm
               name: dshm
-            {{ if (.Values.userPreferences.aiAssistant).enabled }}
+            {{- if $aiAssistant.enabled }}
             - mountPath: /home/{{ .Values.environment.user }}/.continue
               subPath: continue
+              name: config-files
+            - mountPath: /home/{{ .Values.environment.user }}/.config/opencode
+              subPath: opencode
               name: config-files
             {{- end }}
             {{- if (.Values.discovery).hive }}

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -1070,6 +1070,73 @@
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
           }
+        },
+        "aiAssistant": {
+          "title": "AI Assistant",
+          "type": "object",
+          "description": "Configure Jupyter-ai, an extension to use custom AI code assistants",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteSchemaWith": "aiAssistant.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "hidden": true,
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
+              }
+            },
+            "model": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.model"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "hidden": {
+                "value": false,
+                "path": "enabled",
+                "isPathRelative": true
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
+              }
+            }
+          }
         }
       }
     },

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -661,16 +661,48 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "default": "" },
-              "name": { "type": "string", "default": "" },
-              "provider": { "type": "string", "default": "" },
-              "apiBase": { "type": "string", "default": "" },
-              "apiKey": { "type": "string", "default": "" },
-              "selectedModel": { "type": "string", "default": "" },
+              "id": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{id}}" }
+              },
+              "name": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{name}}" }
+              },
+              "provider": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{provider}}" }
+              },
+              "apiBase": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiBase}}" }
+              },
+              "apiKey": {
+                "type": "string",
+                "default": "",
+                "x-onyxia": { "overwriteDefaultWith": "{{apiKey}}" }
+              },
+              "selectedModel": {
+                "type": "string",
+                "listEnum": [],
+                "default": "",
+                "x-onyxia": {
+                  "overwriteDefaultWith": "{{selectedModel}}",
+                  "overwriteListEnumWith": "{{models}}"
+                }
+              },
               "models": {
                 "type": "array",
                 "default": [],
-                "items": { "type": "string" }
+                "items": { "type": "string" },
+                "x-onyxia": {
+                  "hidden": true,
+                  "overwriteDefaultWith": "{{models}}"
+                }
               }
             }
           },

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -591,70 +591,49 @@
             "overwriteDefaultWith": "{{ai.enabled}}"
           }
         },
-        "provider": {
-          "title": "Provider",
-          "type": "string",
-          "default": "",
+        "activeProvider": {
+          "type": "object",
+          "default": {},
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
+          "properties": {
+            "id": { "type": "string", "default": "" },
+            "name": { "type": "string", "default": "" },
+            "provider": { "type": "string", "default": "" },
+            "apiBase": { "type": "string", "default": "" },
+            "apiKey": { "type": "string", "default": "" },
+            "selectedModel": { "type": "string", "default": "" },
+            "models": { "type": "array", "default": [], "items": { "type": "string" } }
+          },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.provider}}"
+            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
-        "model": {
-          "title": "Model",
-          "type": "string",
-          "default": "",
+        "providers": {
+          "type": "array",
+          "default": [],
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
           },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.model}}"
-          }
-        },
-        "embeddingsModel": {
-          "title": "Embeddings model",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "default": "" },
+              "name": { "type": "string", "default": "" },
+              "provider": { "type": "string", "default": "" },
+              "apiBase": { "type": "string", "default": "" },
+              "apiKey": { "type": "string", "default": "" },
+              "selectedModel": { "type": "string", "default": "" },
+              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+            }
           },
           "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.embeddingsModel}}"
-          }
-        },
-        "apiBase": {
-          "title": "API base URL",
-          "type": "string",
-          "default": "",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiBase}}"
-          }
-        },
-        "apiKey": {
-          "title": "API key",
-          "type": "string",
-          "default": "",
-          "render": "password",
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.apiKey}}"
+            "overwriteDefaultWith": "{{ai.providers}}"
           }
         }
       }

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -14,11 +14,7 @@
               "title": "Pull image from registry",
               "type": "string",
               "default": "IfNotPresent",
-              "enum": [
-                "IfNotPresent",
-                "Always",
-                "Never"
-              ]
+              "enum": ["IfNotPresent", "Always", "Never"]
             },
             "version": {
               "title": "Name of the service's Docker image",
@@ -270,11 +266,7 @@
             "value": false,
             "path": "kubernetes/enabled"
           },
-          "listEnum": [
-            "view",
-            "edit",
-            "admin"
-          ],
+          "listEnum": ["view", "edit", "admin"],
           "render": "list"
         }
       }
@@ -584,6 +576,89 @@
         }
       }
     },
+    "ai": {
+      "title": "AI Assistant",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "ai.json"
+      },
+      "properties": {
+        "enabled": {
+          "title": "Enable AI assistant tools",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.enabled}}"
+          }
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.provider}}"
+          }
+        },
+        "model": {
+          "title": "Model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.model}}"
+          }
+        },
+        "embeddingsModel": {
+          "title": "Embeddings model",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.embeddingsModel}}"
+          }
+        },
+        "apiBase": {
+          "title": "API base URL",
+          "type": "string",
+          "default": "",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiBase}}"
+          }
+        },
+        "apiKey": {
+          "title": "API key",
+          "type": "string",
+          "default": "",
+          "render": "password",
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{ai.apiKey}}"
+          }
+        }
+      }
+    },
     "networking": {
       "title": "Network access",
       "type": "object",
@@ -794,7 +869,7 @@
             "hidden": true
           }
         },
-        "tlsSecretName":{
+        "tlsSecretName": {
           "type": "string",
           "default": "",
           "x-onyxia": {
@@ -937,85 +1012,6 @@
             "hidden": true,
             "overwriteDefaultWith": "user.lang"
           }
-        },
-        "aiAssistant":{
-          "title": "AI Assistant",
-          "type": "object",
-          "description": "Configure Continue, an extension to use custom AI code assistants",
-          "x-onyxia": {
-            "overwriteSchemaWith": "aiAssistant.json"
-          },
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false,
-              "hidden": true,
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.enabled"
-              }
-            },
-            "model": {
-              "type": "string",
-              "default":"",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.model"
-              }
-            },
-            "provider": {
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.provider"
-              }
-            },
-            "apiBase":{
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiBase"
-              }
-            },
-            "apiKey":{
-              "type": "string",
-              "default": "",
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.apiKey"
-              }
-            },
-            "useLegacyCompletionsEndpoint":{
-              "title": "use legacy completions endpoint",
-              "type": "boolean",
-              "default": true,
-              "hidden": {
-                "value": false,
-                "path": "enabled",
-                "isPathRelative": true
-              },
-              "x-onyxia": {
-                "overwriteDefaultWith": "user.profile.aiAssistant.useLegacyCompletionsEndpoint"
-              }
-            }
-          }
         }
       }
     },
@@ -1120,7 +1116,7 @@
         }
       }
     },
-    "runtimeClassName" : {
+    "runtimeClassName": {
       "type": "string",
       "description": "Runtime Class Name",
       "default": "",

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -594,32 +594,70 @@
         "activeProvider": {
           "type": "object",
           "default": {},
+          "properties": {
+            "id": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.id}}"
+              }
+            },
+            "name": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.name}}"
+              }
+            },
+            "provider": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.provider}}"
+              }
+            },
+            "apiBase": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiBase}}"
+              }
+            },
+            "apiKey": {
+              "type": "string",
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.apiKey}}"
+              }
+            },
+            "selectedModel": {
+              "type": "string",
+              "listEnum": [""],
+              "default": "",
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{ai.activeProvider.selectedModel}}",
+                "overwriteListEnumWith": "{{ai.activeProvider.models}}"
+              }
+            },
+            "models": {
+              "type": "array",
+              "default": [],
+              "items": { "type": "string" },
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "{{ai.activeProvider.models}}"
+              }
+            }
+          },
           "hidden": {
             "value": false,
             "path": "enabled",
             "isPathRelative": true
-          },
-          "properties": {
-            "id": { "type": "string", "default": "" },
-            "name": { "type": "string", "default": "" },
-            "provider": { "type": "string", "default": "" },
-            "apiBase": { "type": "string", "default": "" },
-            "apiKey": { "type": "string", "default": "" },
-            "selectedModel": { "type": "string", "default": "" },
-            "models": { "type": "array", "default": [], "items": { "type": "string" } }
-          },
-          "x-onyxia": {
-            "overwriteDefaultWith": "{{ai.activeProvider}}"
           }
         },
         "providers": {
           "type": "array",
           "default": [],
-          "hidden": {
-            "value": false,
-            "path": "enabled",
-            "isPathRelative": true
-          },
           "items": {
             "type": "object",
             "properties": {
@@ -629,11 +667,20 @@
               "apiBase": { "type": "string", "default": "" },
               "apiKey": { "type": "string", "default": "" },
               "selectedModel": { "type": "string", "default": "" },
-              "models": { "type": "array", "default": [], "items": { "type": "string" } }
+              "models": {
+                "type": "array",
+                "default": [],
+                "items": { "type": "string" }
+              }
             }
           },
           "x-onyxia": {
             "overwriteDefaultWith": "{{ai.providers}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "enabled",
+            "isPathRelative": true
           }
         }
       }

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -243,11 +243,8 @@ startupProbe:
 ai:
   enabled: false
   secretName: ""  # Generated based on the service's name if empty or not set
-  provider: ""
-  model: ""
-  embeddingsModel: ""
-  apiBase: ""
-  apiKey: ""
+  activeProvider: {}
+  providers: []
 
 userPreferences:
   darkMode: false

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -240,7 +240,7 @@ startupProbe:
   successThreshold: 1
   timeoutSeconds: 2
 
-aiAssistant:
+ai:
   enabled: false
   secretName: ""  # Generated based on the service's name if empty or not set
   provider: ""

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -240,17 +240,18 @@ startupProbe:
   successThreshold: 1
   timeoutSeconds: 2
 
+aiAssistant:
+  enabled: false
+  secretName: ""  # Generated based on the service's name if empty or not set
+  provider: ""
+  model: ""
+  embeddingsModel: ""
+  apiBase: ""
+  apiKey: ""
+
 userPreferences:
   darkMode: false
   language: "en"
-  aiAssistant:
-    enabled: false
-    model: ""
-    provider: ""
-    apiBase: ""
-    apiKey: ""
-    secretName: ""  # Generated based on the service's name if empty or not set
-    useLegacyCompletionsEndpoint: false
 
 openshiftSCC:
   enabled: false

--- a/test
+++ b/test
@@ -1,0 +1,3 @@
+for c in jupyter-pyspark jupyter-python vscode-pyspark vscode-python rstudio; do
+  cp -R "helm-charts-interactive-services/charts/$c/." "helm-charts-dev/charts/$c-ia/"
+done

--- a/test
+++ b/test
@@ -1,3 +1,0 @@
-for c in jupyter-pyspark jupyter-python vscode-pyspark vscode-python rstudio; do
-  cp -R "helm-charts-interactive-services/charts/$c/." "helm-charts-dev/charts/$c-ia/"
-done


### PR DESCRIPTION
<!--
 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change


### Checklist

- [x] Chart version bumped in `Chart.yaml`
- [ ] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
