### PR TITLE
library-chart Disable path when using passthrough termination on route

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 2.1.3
+version: 2.1.4
 type: library

--- a/charts/library-chart/templates/_route.tpl
+++ b/charts/library-chart/templates/_route.tpl
@@ -34,7 +34,9 @@ metadata:
     {{- include "library-chart.route.annotations" . | nindent 4 }}
 spec:
   host: {{ .Values.route.hostname | quote }}
+  {{- if ne .Values.route.tls.termination "passthrough" }}
   path: {{ .Values.route.path | default "/" }}
+  {{- end }}
   to:
     kind: Service
     name: {{ $fullName }}
@@ -83,7 +85,9 @@ spec:
 {{- else }}
   host: {{ regexReplaceAll "([^\\.]+)\\.(.*)" .Values.route.userHostname (printf "${1}-%d.${2}" (int $userPort)) | quote }}
 {{- end }}
+  {{- if ne .Values.route.tls.termination "passthrough" }}
   path: {{ .Values.route.userPath | default "/" }}
+  {{- end }}
   to:
     kind: Service
     name: {{ $fullName }}
@@ -130,7 +134,9 @@ metadata:
     {{- include "library-chart.route.annotations" . | nindent 4 }}
 spec:
   host: {{ .Values.spark.hostname | quote }}
+  {{- if ne .Values.route.tls.termination "passthrough" }}
   path: {{ .Values.spark.path | default "/" }}
+  {{- end }}
   to:
     kind: Service
     name: {{ $fullName }}


### PR DESCRIPTION

### Description of the change

Disable path when using passthrough termination on route.

```
Error: Route.route.openshift.io "vscode-openstack-91470-ui" is invalid: spec.path: Invalid value: "/": passthrough termination does not support paths
```

### Checklist

- [x] Chart version bumped in `Chart.yaml`
- [x] Title of the pull request follows this pattern [name_of_the_chart] Descriptive title
